### PR TITLE
[WS1] Control-plane API (FastAPI) for the UI

### DIFF
--- a/workstreams/ws1-annotation-validation/.gitignore
+++ b/workstreams/ws1-annotation-validation/.gitignore
@@ -7,3 +7,6 @@ results/
 # nf-test artifacts
 .nf-test/
 .nf-test.log
+
+# control-plane API run dirs (per-run work/results + uploads)
+.api_runs/

--- a/workstreams/ws1-annotation-validation/README.md
+++ b/workstreams/ws1-annotation-validation/README.md
@@ -86,6 +86,26 @@ can be adapted into `ws1-parse` / `ws1-validate`.
 3. Teach `bin/ws1-parse` to read its native output.
 4. Add the name to `--annotators` — the `ANNOTATE` process is generic over the tool.
 
+## Driving runs from a UI (control-plane API)
+
+Nextflow has no native control API, so `api/` ships a thin **FastAPI** backend a UI drives to
+launch, monitor (live), and fetch results — full details in [`api/README.md`](api/README.md).
+
+```bash
+conda activate ws1-dev            # includes fastapi + uvicorn
+uvicorn api.app:app --port 8000   # interactive docs at http://127.0.0.1:8000/docs
+```
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/tools`, `/profiles` | options for the UI form |
+| POST | `/uploads` | upload a structure |
+| POST | `/runs` | launch a run `{input?, annotators?, profile}` |
+| GET | `/runs[/{id}]` | list / status + task progress |
+| GET | `/runs/{id}/events` | SSE live progress (fed by Nextflow `-with-weblog`) |
+| GET | `/runs/{id}/results[/{path}]` | list / download published outputs |
+| DELETE | `/runs/{id}` | cancel a run |
+
 ## Layout
 
 ```
@@ -94,6 +114,7 @@ nextflow.config    params + profiles (conda/mamba/docker/singularity/test)
 modules/           one .nf process per stage
 bin/               stage CLIs — the team contract (stubs for now)
 envs/              per-process conda envs (one per tool/stage)
+api/               control-plane API (FastAPI) the UI drives — see api/README.md
 environment.yml    ws1-dev developer toolchain (this is NOT a pipeline env)
 read_write_mmcif/  reference parser/converter snippets (PR #46)
 ```

--- a/workstreams/ws1-annotation-validation/api/README.md
+++ b/workstreams/ws1-annotation-validation/api/README.md
@@ -1,0 +1,62 @@
+# WS1 control-plane API
+
+A thin **FastAPI** backend the UI drives to control the Nextflow pipeline: list
+options, launch / monitor / cancel runs, stream live progress, and serve results.
+It wraps the `nextflow` CLI (the skeleton in the parent directory) — there is no
+native Nextflow control API, so this layer provides one.
+
+```
+React UI ──HTTP/SSE──▶ this API ──subprocess──▶ nextflow run main.nf …
+                          ▲                              │
+                          └────── -with-weblog (events) ─┘
+```
+
+## Run it
+
+```bash
+conda activate ws1-dev
+cd workstreams/ws1-annotation-validation
+uvicorn api.app:app --reload --port 8000
+```
+
+Interactive docs (OpenAPI) at `http://127.0.0.1:8000/docs`. If the server is not
+reachable at `http://127.0.0.1:8000`, set `WS1_API_BASE_URL` so Nextflow's weblog
+callback points back correctly.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/tools` | annotator names available (from `envs/*.yml`) |
+| GET | `/profiles` | Nextflow profiles (`conda`, `mamba`, `docker`, `singularity`, `test`) |
+| POST | `/uploads` | upload a `.pdb`/`.cif`; returns a server `input` path |
+| POST | `/runs` | launch a run — body `{input?, annotators?, profile}` |
+| GET | `/runs` | list runs |
+| GET | `/runs/{id}` | run status + task progress |
+| DELETE | `/runs/{id}` | cancel a run |
+| GET | `/runs/{id}/events` | **SSE** live progress until the run ends |
+| GET | `/runs/{id}/results` | list published result files |
+| GET | `/runs/{id}/results/{path}` | download a result file |
+
+`POST /runs/{id}/_weblog` is internal — Nextflow posts events there.
+
+## Example
+
+```bash
+# fast end-to-end run on the bundled 9CFN (no tool installs)
+curl -s -X POST localhost:8000/runs -H 'content-type: application/json' \
+     -d '{"profile":"test"}'
+# -> {"id":"<run_id>", "status":"running", ...}
+
+curl -s localhost:8000/runs/<run_id>                       # status
+curl -sN localhost:8000/runs/<run_id>/events               # live SSE stream
+curl -s localhost:8000/runs/<run_id>/results               # {"files":[...]}
+curl -s localhost:8000/runs/<run_id>/results/validation/validation_report.json
+```
+
+## Limitations (first prototype)
+
+- Run state is in-memory (lost on restart); no persistence/DB yet.
+- CORS is wide open for dev — tighten `allow_origins` before any deployment.
+- No auth; intended for local/hackathon use.
+- Per-run dirs live under `.api_runs/` (git-ignored).

--- a/workstreams/ws1-annotation-validation/api/README.md
+++ b/workstreams/ws1-annotation-validation/api/README.md
@@ -29,8 +29,8 @@ callback points back correctly.
 |---|---|---|
 | GET | `/tools` | annotator names available (from `envs/*.yml`) |
 | GET | `/profiles` | Nextflow profiles (`conda`, `mamba`, `docker`, `singularity`, `test`) |
-| POST | `/uploads` | upload a `.pdb`/`.cif`; returns a server `input` path |
-| POST | `/runs` | launch a run — body `{input?, annotators?, profile}` |
+| POST | `/uploads` | upload a `.pdb`/`.cif`/`.mmcif`; returns an opaque `upload_id` |
+| POST | `/runs` | launch a run — body `{input?: upload_id, annotators?, profile}` |
 | GET | `/runs` | list runs |
 | GET | `/runs/{id}` | run status + task progress |
 | DELETE | `/runs/{id}` | cancel a run |
@@ -43,10 +43,15 @@ callback points back correctly.
 ## Example
 
 ```bash
-# fast end-to-end run on the bundled 9CFN (no tool installs)
+# fast end-to-end run on the bundled 9CFN (no upload, no tool installs)
 curl -s -X POST localhost:8000/runs -H 'content-type: application/json' \
      -d '{"profile":"test"}'
 # -> {"id":"<run_id>", "status":"running", ...}
+
+# run on your own structure: upload first, then pass the returned id
+UID=$(curl -s -X POST localhost:8000/uploads -F 'file=@my.cif' | jq -r .upload_id)
+curl -s -X POST localhost:8000/runs -H 'content-type: application/json' \
+     -d "{\"profile\":\"conda\",\"input\":\"$UID\"}"
 
 curl -s localhost:8000/runs/<run_id>                       # status
 curl -sN localhost:8000/runs/<run_id>/events               # live SSE stream
@@ -54,9 +59,20 @@ curl -s localhost:8000/runs/<run_id>/results               # {"files":[...]}
 curl -s localhost:8000/runs/<run_id>/results/validation/validation_report.json
 ```
 
+## Security model
+
+No user-controlled value ever forms a filesystem path:
+
+- **Inputs** are referenced by an opaque `upload_id` (a dict key), and the server
+  resolves it to a path it generated; arbitrary server paths can't be requested.
+- **Uploads** are stored as `<generated-id><allowlisted-suffix>` — the original
+  filename never forms the path.
+- **Results** are served only if the requested relative path is in that run's own
+  result listing (built from a trusted directory walk).
+
 ## Limitations (first prototype)
 
-- Run state is in-memory (lost on restart); no persistence/DB yet.
+- Run state + the upload registry are in-memory (lost on restart); no persistence/DB yet.
 - CORS is wide open for dev — tighten `allow_origins` before any deployment.
 - No auth; intended for local/hackathon use.
-- Per-run dirs live under `.api_runs/` (git-ignored).
+- Per-run dirs and uploads live under `.api_runs/` (git-ignored).

--- a/workstreams/ws1-annotation-validation/api/__init__.py
+++ b/workstreams/ws1-annotation-validation/api/__init__.py
@@ -1,0 +1,1 @@
+"""WS1 control-plane API — the UI backend that drives the Nextflow pipeline."""

--- a/workstreams/ws1-annotation-validation/api/app.py
+++ b/workstreams/ws1-annotation-validation/api/app.py
@@ -14,21 +14,20 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import re
 from pathlib import Path
 
 from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
 
-from .models import RunInfo, RunRequest
-from .runner import RunManager, UPLOAD_DIR
+from .models import RunInfo, RunRequest, UploadInfo
+from .runner import RunManager
 
 BASE_URL = os.environ.get("WS1_API_BASE_URL", "http://127.0.0.1:8000")
 
-# Upload hardening: strict filename charset, structure-only extensions, size cap.
-SAFE_FILENAME = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
-ALLOWED_SUFFIXES = {".pdb", ".cif", ".mmcif"}
+# Uploads are stored under a server-generated id; only the allowlisted suffix from
+# the original name is reused, so no user-controlled string ever forms a path.
+SUFFIX_BY_EXT = {".pdb": ".pdb", ".cif": ".cif", ".mmcif": ".mmcif"}
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 
 app = FastAPI(title="WS1 control plane", version="0.1.0")
@@ -50,20 +49,18 @@ def profiles() -> dict:
     return {"profiles": mgr.list_profiles()}
 
 
-@app.post("/uploads")
-async def upload(file: UploadFile = File(...)) -> dict:
+@app.post("/uploads", response_model=UploadInfo)
+async def upload(file: UploadFile = File(...)) -> UploadInfo:
     name = os.path.basename(file.filename or "")
-    if (name in {"", ".", ".."} or not SAFE_FILENAME.match(name)
-            or Path(name).suffix.lower() not in ALLOWED_SUFFIXES):
-        raise HTTPException(400, "filename must be [A-Za-z0-9._-] ending in .pdb/.cif/.mmcif")
+    # Reuse only the extension, mapped to a literal — never the user string.
+    ext = SUFFIX_BY_EXT.get(Path(name).suffix.lower())
+    if ext is None:
+        raise HTTPException(400, "structure file must be .pdb/.cif/.mmcif")
     data = await file.read()
     if len(data) > MAX_UPLOAD_BYTES:
         raise HTTPException(413, "uploaded file too large")
-    dest = (UPLOAD_DIR / name).resolve()
-    if dest.parent != UPLOAD_DIR.resolve():        # must land directly in uploads
-        raise HTTPException(400, "invalid filename")
-    dest.write_bytes(data)
-    return {"input": str(dest)}
+    upload_id = mgr.register_upload(ext, data)
+    return UploadInfo(upload_id=upload_id, filename=name)
 
 
 @app.post("/runs", response_model=RunInfo)
@@ -140,10 +137,8 @@ def results(run_id: str) -> dict:
 def result_file(run_id: str, rel: str) -> FileResponse:
     if mgr.get(run_id) is None:
         raise HTTPException(404, "run not found")
-    try:
-        path = mgr.result_path(run_id, rel)
-    except ValueError:
-        raise HTTPException(400, "invalid path")
+    # Only paths present in the run's own result listing are servable.
+    path = mgr.result_path(run_id, rel)
     if path is None:
         raise HTTPException(404, "file not found")
     return FileResponse(path)

--- a/workstreams/ws1-annotation-validation/api/app.py
+++ b/workstreams/ws1-annotation-validation/api/app.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
+from pathlib import Path
 
 from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,6 +25,11 @@ from .models import RunInfo, RunRequest
 from .runner import RunManager, UPLOAD_DIR
 
 BASE_URL = os.environ.get("WS1_API_BASE_URL", "http://127.0.0.1:8000")
+
+# Upload hardening: strict filename charset, structure-only extensions, size cap.
+SAFE_FILENAME = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
+ALLOWED_SUFFIXES = {".pdb", ".cif", ".mmcif"}
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 
 app = FastAPI(title="WS1 control plane", version="0.1.0")
 # Permissive CORS for dev so the React app (different origin) can call the API.
@@ -45,14 +52,26 @@ def profiles() -> dict:
 
 @app.post("/uploads")
 async def upload(file: UploadFile = File(...)) -> dict:
-    dest = UPLOAD_DIR / os.path.basename(file.filename or "structure")
-    dest.write_bytes(await file.read())
+    name = os.path.basename(file.filename or "")
+    if (name in {"", ".", ".."} or not SAFE_FILENAME.match(name)
+            or Path(name).suffix.lower() not in ALLOWED_SUFFIXES):
+        raise HTTPException(400, "filename must be [A-Za-z0-9._-] ending in .pdb/.cif/.mmcif")
+    data = await file.read()
+    if len(data) > MAX_UPLOAD_BYTES:
+        raise HTTPException(413, "uploaded file too large")
+    dest = (UPLOAD_DIR / name).resolve()
+    if dest.parent != UPLOAD_DIR.resolve():        # must land directly in uploads
+        raise HTTPException(400, "invalid filename")
+    dest.write_bytes(data)
     return {"input": str(dest)}
 
 
 @app.post("/runs", response_model=RunInfo)
 async def create_run(req: RunRequest) -> RunInfo:
-    return await mgr.launch(req)
+    try:
+        return await mgr.launch(req)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
 
 
 @app.get("/runs", response_model=list[RunInfo])
@@ -119,6 +138,8 @@ def results(run_id: str) -> dict:
 
 @app.get("/runs/{run_id}/results/{rel:path}")
 def result_file(run_id: str, rel: str) -> FileResponse:
+    if mgr.get(run_id) is None:
+        raise HTTPException(404, "run not found")
     try:
         path = mgr.result_path(run_id, rel)
     except ValueError:

--- a/workstreams/ws1-annotation-validation/api/app.py
+++ b/workstreams/ws1-annotation-validation/api/app.py
@@ -1,0 +1,128 @@
+"""WS1 control-plane API.
+
+A thin FastAPI layer the React UI drives: advertise options, launch/monitor/cancel
+Nextflow runs, stream live progress (SSE), and serve published results.
+
+Run it (from the workstream dir, with the ws1-dev env active):
+    uvicorn api.app:app --reload --port 8000
+
+The weblog callback URL must match where this server is reachable; override with
+the WS1_API_BASE_URL env var if not http://127.0.0.1:8000.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, StreamingResponse
+
+from .models import RunInfo, RunRequest
+from .runner import RunManager, UPLOAD_DIR
+
+BASE_URL = os.environ.get("WS1_API_BASE_URL", "http://127.0.0.1:8000")
+
+app = FastAPI(title="WS1 control plane", version="0.1.0")
+# Permissive CORS for dev so the React app (different origin) can call the API.
+# Tighten allow_origins before any non-local deployment.
+app.add_middleware(
+    CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"],
+)
+mgr = RunManager(BASE_URL)
+
+
+@app.get("/tools")
+def tools() -> dict:
+    return {"annotators": mgr.list_annotators()}
+
+
+@app.get("/profiles")
+def profiles() -> dict:
+    return {"profiles": mgr.list_profiles()}
+
+
+@app.post("/uploads")
+async def upload(file: UploadFile = File(...)) -> dict:
+    dest = UPLOAD_DIR / os.path.basename(file.filename or "structure")
+    dest.write_bytes(await file.read())
+    return {"input": str(dest)}
+
+
+@app.post("/runs", response_model=RunInfo)
+async def create_run(req: RunRequest) -> RunInfo:
+    return await mgr.launch(req)
+
+
+@app.get("/runs", response_model=list[RunInfo])
+def list_runs() -> list[RunInfo]:
+    return mgr.list()
+
+
+@app.get("/runs/{run_id}", response_model=RunInfo)
+def get_run(run_id: str) -> RunInfo:
+    info = mgr.get(run_id)
+    if info is None:
+        raise HTTPException(404, "run not found")
+    return info
+
+
+@app.delete("/runs/{run_id}", response_model=RunInfo)
+async def cancel_run(run_id: str) -> RunInfo:
+    info = await mgr.cancel(run_id)
+    if info is None:
+        raise HTTPException(404, "run not found")
+    return info
+
+
+@app.post("/runs/{run_id}/_weblog")
+async def weblog(run_id: str, request: Request) -> dict:
+    """Internal: Nextflow `-with-weblog` posts run/task events here."""
+    await mgr.ingest_weblog(run_id, await request.json())
+    return {"ok": True}
+
+
+@app.get("/runs/{run_id}/events")
+async def events(run_id: str) -> StreamingResponse:
+    """Server-Sent Events: streams live run/task progress until the run ends."""
+    run = mgr.runs.get(run_id)
+    if run is None:
+        raise HTTPException(404, "run not found")
+
+    async def stream():
+        queue: asyncio.Queue[dict] = asyncio.Queue()
+        run.subscribers.add(queue)            # register before checking, to avoid a race
+        try:
+            if run.info.finished_at is not None:
+                terminal = {"event": "terminated", "status": run.info.status.value,
+                            "exit_code": run.info.exit_code}
+                yield f"data: {json.dumps(terminal)}\n\n"
+                return
+            while True:
+                event = await queue.get()
+                yield f"data: {json.dumps(event)}\n\n"
+                if event.get("event") == "terminated":
+                    break
+        finally:
+            run.subscribers.discard(queue)
+
+    return StreamingResponse(stream(), media_type="text/event-stream")
+
+
+@app.get("/runs/{run_id}/results")
+def results(run_id: str) -> dict:
+    if mgr.get(run_id) is None:
+        raise HTTPException(404, "run not found")
+    return {"files": mgr.results(run_id)}
+
+
+@app.get("/runs/{run_id}/results/{rel:path}")
+def result_file(run_id: str, rel: str) -> FileResponse:
+    try:
+        path = mgr.result_path(run_id, rel)
+    except ValueError:
+        raise HTTPException(400, "invalid path")
+    if path is None:
+        raise HTTPException(404, "file not found")
+    return FileResponse(path)

--- a/workstreams/ws1-annotation-validation/api/models.py
+++ b/workstreams/ws1-annotation-validation/api/models.py
@@ -13,12 +13,18 @@ class RunStatus(str, Enum):
     cancelled = "cancelled"
 
 
+class UploadInfo(BaseModel):
+    """Result of POST /uploads — an opaque id to pass back as a run's input."""
+    upload_id: str
+    filename: str
+
+
 class RunRequest(BaseModel):
     """A request to launch a pipeline run."""
     input: str | None = Field(
         default=None,
-        description="Server-side path to a .pdb/.cif (e.g. from POST /uploads). "
-                    "Optional with profile=test, which uses the bundled 9CFN.",
+        description="An upload_id from POST /uploads. Omit with profile=test, "
+                    "which uses the bundled 9CFN.",
     )
     annotators: list[str] | None = Field(
         default=None, description="Annotator names; defaults to the pipeline's config."

--- a/workstreams/ws1-annotation-validation/api/models.py
+++ b/workstreams/ws1-annotation-validation/api/models.py
@@ -1,0 +1,44 @@
+"""Pydantic models for the WS1 control-plane API."""
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class RunStatus(str, Enum):
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+class RunRequest(BaseModel):
+    """A request to launch a pipeline run."""
+    input: str | None = Field(
+        default=None,
+        description="Server-side path to a .pdb/.cif (e.g. from POST /uploads). "
+                    "Optional with profile=test, which uses the bundled 9CFN.",
+    )
+    annotators: list[str] | None = Field(
+        default=None, description="Annotator names; defaults to the pipeline's config."
+    )
+    profile: str = Field(default="conda", description="Nextflow -profile to use.")
+
+
+class TaskProgress(BaseModel):
+    submitted: int = 0
+    completed: int = 0
+    failed: int = 0
+
+
+class RunInfo(BaseModel):
+    id: str
+    status: RunStatus
+    profile: str
+    annotators: list[str] | None = None
+    input: str | None = None
+    started_at: float
+    finished_at: float | None = None
+    exit_code: int | None = None
+    progress: TaskProgress = TaskProgress()

--- a/workstreams/ws1-annotation-validation/api/runner.py
+++ b/workstreams/ws1-annotation-validation/api/runner.py
@@ -1,0 +1,135 @@
+"""Run management: launch Nextflow, ingest its weblog events, expose run state.
+
+The pipeline itself is the skeleton in the parent directory (main.nf). Each run
+gets an isolated dir under .api_runs/<id>/ (work + results). Live progress comes
+from Nextflow's `-with-weblog`, which POSTs JSON events back to this service.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from pathlib import Path
+
+from .models import RunInfo, RunStatus, TaskProgress
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent   # the Nextflow project (main.nf)
+RUNS_DIR = PROJECT_DIR / ".api_runs"
+UPLOAD_DIR = RUNS_DIR / "_uploads"
+RESERVED_ENVS = {"convert", "parse"}                   # stage envs, not annotators
+PROFILES = ["conda", "mamba", "docker", "singularity", "test"]
+
+
+class Run:
+    def __init__(self, info: RunInfo):
+        self.info = info
+        self.proc: asyncio.subprocess.Process | None = None
+        self.subscribers: set[asyncio.Queue[dict]] = set()   # one queue per SSE client
+
+    def publish(self, event: dict) -> None:
+        for queue in list(self.subscribers):
+            queue.put_nowait(event)
+
+
+class RunManager:
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self.runs: dict[str, Run] = {}
+        UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+    # ---- discovery (so the UI can build its form) ----
+    def list_annotators(self) -> list[str]:
+        envs = (PROJECT_DIR / "envs").glob("*.yml")
+        return sorted(p.stem for p in envs if p.stem not in RESERVED_ENVS)
+
+    def list_profiles(self) -> list[str]:
+        return list(PROFILES)
+
+    # ---- run lifecycle ----
+    async def launch(self, req) -> RunInfo:
+        run_id = uuid.uuid4().hex[:12]
+        run_dir = RUNS_DIR / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "nextflow", "run", "main.nf",
+            "-profile", req.profile,
+            "-name", f"ws1-{run_id}",
+            "-work-dir", str(run_dir / "work"),
+            "--outdir", str(run_dir / "results"),
+            "-with-weblog", f"{self.base_url}/runs/{run_id}/_weblog",
+        ]
+        if req.input:
+            cmd += ["--input", req.input]
+        if req.annotators:
+            cmd += ["--annotators", ",".join(req.annotators)]
+
+        info = RunInfo(
+            id=run_id, status=RunStatus.running, profile=req.profile,
+            annotators=req.annotators, input=req.input,
+            started_at=time.time(), progress=TaskProgress(),
+        )
+        run = Run(info)
+        self.runs[run_id] = run
+
+        log = (run_dir / "nextflow.log").open("wb")
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, cwd=str(PROJECT_DIR),
+            stdout=log, stderr=asyncio.subprocess.STDOUT,
+        )
+        run.proc = proc
+        asyncio.create_task(self._watch(run, proc, log))
+        return info
+
+    async def _watch(self, run: Run, proc, log) -> None:
+        code = await proc.wait()
+        log.close()
+        run.info.exit_code = code
+        if run.info.status != RunStatus.cancelled:
+            run.info.status = RunStatus.completed if code == 0 else RunStatus.failed
+        run.info.finished_at = time.time()
+        run.publish({"event": "terminated", "status": run.info.status.value,
+                     "exit_code": code})
+
+    async def ingest_weblog(self, run_id: str, payload: dict) -> None:
+        run = self.runs.get(run_id)
+        if run is None:
+            return
+        event = payload.get("event")
+        if event == "process_submitted":
+            run.info.progress.submitted += 1
+        elif event == "process_completed":
+            run.info.progress.completed += 1
+            if str((payload.get("trace") or {}).get("status")) == "FAILED":
+                run.info.progress.failed += 1
+        run.publish(payload)
+
+    async def cancel(self, run_id: str) -> RunInfo | None:
+        run = self.runs.get(run_id)
+        if run is None:
+            return None
+        if run.proc is not None and run.proc.returncode is None:
+            run.info.status = RunStatus.cancelled
+            run.proc.terminate()
+        return run.info
+
+    # ---- reads ----
+    def get(self, run_id: str) -> RunInfo | None:
+        run = self.runs.get(run_id)
+        return run.info if run else None
+
+    def list(self) -> list[RunInfo]:
+        return [r.info for r in self.runs.values()]
+
+    def results(self, run_id: str) -> list[str]:
+        base = RUNS_DIR / run_id / "results"
+        if not base.exists():
+            return []
+        return sorted(str(p.relative_to(base)) for p in base.rglob("*") if p.is_file())
+
+    def result_path(self, run_id: str, rel: str) -> Path | None:
+        base = (RUNS_DIR / run_id / "results").resolve()
+        target = (base / rel).resolve()
+        if not target.is_relative_to(base):       # block path traversal
+            raise ValueError("path escapes results dir")
+        return target if target.is_file() else None

--- a/workstreams/ws1-annotation-validation/api/runner.py
+++ b/workstreams/ws1-annotation-validation/api/runner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 from .models import RunInfo, RunStatus, TaskProgress
 
@@ -18,9 +18,6 @@ RUNS_DIR = PROJECT_DIR / ".api_runs"
 UPLOAD_DIR = RUNS_DIR / "_uploads"
 RESERVED_ENVS = {"convert", "parse"}                   # stage envs, not annotators
 PROFILES = ["conda", "mamba", "docker", "singularity", "test"]
-# A run's --input must resolve under one of these roots (uploaded files or the
-# bundled data dir) — never an arbitrary server path.
-ALLOWED_INPUT_ROOTS = [UPLOAD_DIR, PROJECT_DIR.parent.parent / "data"]
 
 
 class Run:
@@ -40,6 +37,7 @@ class RunManager:
     def __init__(self, base_url: str):
         self.base_url = base_url.rstrip("/")
         self.runs: dict[str, Run] = {}
+        self.uploads: dict[str, Path] = {}      # upload_id -> trusted stored path
         UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
     # ---- discovery (so the UI can build its form) ----
@@ -50,15 +48,14 @@ class RunManager:
     def list_profiles(self) -> list[str]:
         return list(PROFILES)
 
-    def _validate_input(self, raw: str) -> str:
-        """Confine --input to an uploaded file or the bundled data dir."""
-        path = Path(raw).resolve()
-        roots = [r.resolve() for r in ALLOWED_INPUT_ROOTS]
-        if not any(path.is_relative_to(root) for root in roots):
-            raise ValueError("input must be an uploaded file or bundled data")
-        if not path.is_file():
-            raise ValueError("input file not found")
-        return str(path)
+    def register_upload(self, suffix: str, data: bytes) -> str:
+        """Store an uploaded structure under a server-generated id; return the id.
+        `suffix` is an allowlisted literal, so the path has no user-controlled part."""
+        upload_id = uuid.uuid4().hex[:12]
+        dest = UPLOAD_DIR / f"{upload_id}{suffix}"
+        dest.write_bytes(data)
+        self.uploads[upload_id] = dest
+        return upload_id
 
     # ---- run lifecycle ----
     async def launch(self, req) -> RunInfo:
@@ -71,7 +68,12 @@ class RunManager:
             unknown = [a for a in annotators if a not in allowed]
             if unknown:
                 raise ValueError(f"unknown annotator(s): {unknown}")
-        input_path = self._validate_input(req.input) if req.input else None
+        input_path = None
+        if req.input:                           # req.input is an upload id (used only as a key)
+            stored = self.uploads.get(req.input)
+            if stored is None:
+                raise ValueError("unknown upload id")
+            input_path = str(stored)            # trusted path from the upload registry
 
         run_id = uuid.uuid4().hex[:12]
         run_dir = RUNS_DIR / run_id
@@ -161,11 +163,8 @@ class RunManager:
         run = self.runs.get(run_id)
         if run is None:
             return None
-        base = (run.dir / "results").resolve()     # trusted base (not user input)
-        rel_path = PurePosixPath(rel)
-        if rel_path.is_absolute() or ".." in rel_path.parts:
-            raise ValueError("invalid path")        # reject traversal up-front
-        target = (base / rel).resolve()
-        if not target.is_relative_to(base):         # belt-and-braces containment
-            raise ValueError("path escapes results dir")
-        return target if target.is_file() else None
+        listing = self.results(run_id)              # trusted relative paths (from rglob)
+        if rel not in listing:
+            return None                             # only files in the run's own listing
+        # Build from the trusted listing entry, not the raw request string.
+        return run.dir / "results" / listing[listing.index(rel)]

--- a/workstreams/ws1-annotation-validation/api/runner.py
+++ b/workstreams/ws1-annotation-validation/api/runner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from .models import RunInfo, RunStatus, TaskProgress
 
@@ -18,6 +18,9 @@ RUNS_DIR = PROJECT_DIR / ".api_runs"
 UPLOAD_DIR = RUNS_DIR / "_uploads"
 RESERVED_ENVS = {"convert", "parse"}                   # stage envs, not annotators
 PROFILES = ["conda", "mamba", "docker", "singularity", "test"]
+# A run's --input must resolve under one of these roots (uploaded files or the
+# bundled data dir) — never an arbitrary server path.
+ALLOWED_INPUT_ROOTS = [UPLOAD_DIR, PROJECT_DIR.parent.parent / "data"]
 
 
 class Run:
@@ -25,6 +28,8 @@ class Run:
         self.info = info
         self.proc: asyncio.subprocess.Process | None = None
         self.subscribers: set[asyncio.Queue[dict]] = set()   # one queue per SSE client
+        # Trusted run dir, built from the server-generated id (never user input).
+        self.dir: Path = RUNS_DIR / info.id
 
     def publish(self, event: dict) -> None:
         for queue in list(self.subscribers):
@@ -45,8 +50,29 @@ class RunManager:
     def list_profiles(self) -> list[str]:
         return list(PROFILES)
 
+    def _validate_input(self, raw: str) -> str:
+        """Confine --input to an uploaded file or the bundled data dir."""
+        path = Path(raw).resolve()
+        roots = [r.resolve() for r in ALLOWED_INPUT_ROOTS]
+        if not any(path.is_relative_to(root) for root in roots):
+            raise ValueError("input must be an uploaded file or bundled data")
+        if not path.is_file():
+            raise ValueError("input file not found")
+        return str(path)
+
     # ---- run lifecycle ----
     async def launch(self, req) -> RunInfo:
+        # Validate every user-supplied value before it reaches the command line.
+        if req.profile not in PROFILES:
+            raise ValueError(f"unknown profile {req.profile!r}")
+        annotators = req.annotators
+        if annotators:
+            allowed = set(self.list_annotators())
+            unknown = [a for a in annotators if a not in allowed]
+            if unknown:
+                raise ValueError(f"unknown annotator(s): {unknown}")
+        input_path = self._validate_input(req.input) if req.input else None
+
         run_id = uuid.uuid4().hex[:12]
         run_dir = RUNS_DIR / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
@@ -59,14 +85,14 @@ class RunManager:
             "--outdir", str(run_dir / "results"),
             "-with-weblog", f"{self.base_url}/runs/{run_id}/_weblog",
         ]
-        if req.input:
-            cmd += ["--input", req.input]
-        if req.annotators:
-            cmd += ["--annotators", ",".join(req.annotators)]
+        if input_path:
+            cmd += ["--input", input_path]
+        if annotators:
+            cmd += ["--annotators", ",".join(annotators)]
 
         info = RunInfo(
             id=run_id, status=RunStatus.running, profile=req.profile,
-            annotators=req.annotators, input=req.input,
+            annotators=annotators, input=input_path,
             started_at=time.time(), progress=TaskProgress(),
         )
         run = Run(info)
@@ -122,14 +148,24 @@ class RunManager:
         return [r.info for r in self.runs.values()]
 
     def results(self, run_id: str) -> list[str]:
-        base = RUNS_DIR / run_id / "results"
+        # run_id is only a dict key; the path comes from the trusted run.dir.
+        run = self.runs.get(run_id)
+        if run is None:
+            return []
+        base = run.dir / "results"
         if not base.exists():
             return []
         return sorted(str(p.relative_to(base)) for p in base.rglob("*") if p.is_file())
 
     def result_path(self, run_id: str, rel: str) -> Path | None:
-        base = (RUNS_DIR / run_id / "results").resolve()
+        run = self.runs.get(run_id)
+        if run is None:
+            return None
+        base = (run.dir / "results").resolve()     # trusted base (not user input)
+        rel_path = PurePosixPath(rel)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            raise ValueError("invalid path")        # reject traversal up-front
         target = (base / rel).resolve()
-        if not target.is_relative_to(base):       # block path traversal
+        if not target.is_relative_to(base):         # belt-and-braces containment
             raise ValueError("path escapes results dir")
         return target if target.is_file() else None

--- a/workstreams/ws1-annotation-validation/environment.yml
+++ b/workstreams/ws1-annotation-validation/environment.yml
@@ -16,5 +16,8 @@ dependencies:
   - gemmi                # mmCIF/PDB IO for parser + validator development
   - nf-test              # pipeline tests
   - pytest               # unit tests for the stub stage CLIs
+  - fastapi              # control-plane API (the UI backend)
+  - uvicorn              # ASGI server for the API
+  - python-multipart     # structure-file uploads in the API
 # Per-tool dependencies (rnapolis, fr3d, ...) are NOT here — they live in the
 # per-process pipeline envs under envs/*.yml and are built by Nextflow.

--- a/workstreams/ws1-annotation-validation/nextflow.config
+++ b/workstreams/ws1-annotation-validation/nextflow.config
@@ -27,7 +27,7 @@ profiles {
     singularity { singularity.enabled = true; singularity.autoMounts = true }
     test {
         conda.enabled    = false
-        params.input      = "${projectDir}/../../data/9CFN_clean.cif"
+        params.input      = "${projectDir}/../../data/9CFN/9CFN_clean.cif"
         params.annotators = 'fr3d,rnapolis'
     }
 }


### PR DESCRIPTION
## Summary

A thin **FastAPI** backend so a UI can drive the Nextflow pipeline. Nextflow has no native control API, so this provides one: advertise options, launch / monitor (live) / cancel runs, and serve results.

## What it adds (`api/`)

- `GET /tools`, `/profiles` — annotators + profiles for the UI form
- `POST /uploads` — upload a structure
- `POST /runs` — launch `{input?, annotators?, profile}`; `GET /runs[/{id}]` — list / status + task progress
- `GET /runs/{id}/events` — **SSE** live progress, fed by Nextflow `-with-weblog`
- `GET /runs/{id}/results[/{path}]` — list / download published outputs
- `DELETE /runs/{id}` — cancel a run
- per-run isolation under `.api_runs/<id>/`; API dev deps added to `environment.yml`

## How to test

```bash
conda activate ws1-dev
cd workstreams/ws1-annotation-validation
uvicorn api.app:app --port 8000              # interactive docs at /docs
curl -X POST localhost:8000/runs -H 'content-type: application/json' -d '{"profile":"test"}'
curl -N localhost:8000/runs/<id>/events      # live progress (SSE)
curl localhost:8000/runs/<id>/results
```

Verified end to end: a `profile=test` run streams all 6 task events over SSE and serves `validation_report.json`.

## Limitations (first prototype)

- In-memory run state (lost on restart); no persistence/DB yet.
- CORS wide open and no auth — local/hackathon use; tighten before any deploy.
- The React frontend is owned separately; this is the API contract it codes against.

Closes #55. Builds on #50 (skeleton).