### PR TITLE
[WS1] Simpler default run: positional input, fr3d default, tidy logs

### DIFF
--- a/workstreams/ws1-annotation-validation/README.md
+++ b/workstreams/ws1-annotation-validation/README.md
@@ -23,8 +23,8 @@ conda activate ws1-dev
 # 2. smoke test — runs end-to-end on the bundled 9CFN data, no tool installs needed
 nextflow run main.nf -profile test
 
-# 3. a real run
-nextflow run main.nf --input ../../data/9CFN_clean.cif --annotators fr3d,rnapolis -profile conda
+# 3. a real run — defaults: fr3d annotator, conda envs
+nextflow run main.nf --input ../../data/9CFN_clean.cif
 ```
 
 Results are written under `--outdir` (default `results/`):
@@ -41,8 +41,8 @@ results/
 
 | Param | Default | Meaning |
 |---|---|---|
-| `--input` | _(required)_ | Structure file, `.pdb` or `.cif` |
-| `--annotators` | `fr3d,rnapolis` | Comma-separated annotator names (one `envs/<name>.yml` each) |
+| `--input` | _(required)_ | Structure file, `.pdb` or `.cif` — may also be passed positionally (`nextflow run main.nf <file>`) |
+| `--annotators` | `fr3d` | Comma-separated annotator names, e.g. `fr3d,rnapolis` (one `envs/<name>.yml` each) |
 | `--outdir` | `results` | Output directory |
 
 ## Environments (profiles)

--- a/workstreams/ws1-annotation-validation/environment.yml
+++ b/workstreams/ws1-annotation-validation/environment.yml
@@ -18,3 +18,8 @@ dependencies:
   - pytest               # unit tests for the stub stage CLIs
 # Per-tool dependencies (rnapolis, fr3d, ...) are NOT here — they live in the
 # per-process pipeline envs under envs/*.yml and are built by Nextflow.
+variables:
+  # Tuck Nextflow's run log into .nextflow/ (already git-ignored) instead of
+  # littering the repo root with .nextflow.log* — there is no nextflow.config
+  # setting for the log path, so it must be an env var, set here on activate.
+  NXF_LOG_FILE: .nextflow/nextflow.log

--- a/workstreams/ws1-annotation-validation/main.nf
+++ b/workstreams/ws1-annotation-validation/main.nf
@@ -9,11 +9,14 @@ include { PARSE    } from './modules/parse.nf'
 include { VALIDATE } from './modules/validate.nf'
 
 workflow {
-    if( !params.input )
-        error "No input. Use --input <structure.pdb|.cif>  (or -profile test for the bundled 9CFN)"
+    // Input accepted either as a bare positional arg (nextflow run main.nf <file>)
+    // or via the --input flag; -profile test sets it to the bundled 9CFN.
+    def input = params.input ?: ( args ? args[0] : null )
+    if( !input )
+        error "No input. Pass a structure positionally (nextflow run main.nf <file>) or with --input <file>  (or -profile test for the bundled 9CFN)"
 
     // Input
-    structure_ch = Channel.fromPath(params.input, checkIfExists: true)
+    structure_ch = Channel.fromPath(input, checkIfExists: true)
 
     // T1 Conversion: any structure -> standardized mmCIF
     mmcif_ch = CONVERT(structure_ch)

--- a/workstreams/ws1-annotation-validation/nextflow.config
+++ b/workstreams/ws1-annotation-validation/nextflow.config
@@ -12,7 +12,7 @@ manifest {
 
 params {
     input      = null              // structure: .pdb or .cif  (required)
-    annotators = 'fr3d,rnapolis'   // comma-separated annotator names (one per env/<name>.yml)
+    annotators = 'fr3d'            // comma-separated annotator names (one per env/<name>.yml)
     outdir     = 'results'
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #51, addressing review feedback (flag-free default run + a smaller default annotator set).

- **Positional input** — accept a structure as a bare arg, `nextflow run main.nf <file>`, in addition to `--input <file>`. `-profile test` still injects the bundled 9CFN.
- **Smaller default** — default annotator reduced to `fr3d`, so a bare run no longer fans out to two tools. The `test` profile still runs `fr3d,rnapolis` to exercise the cross-tool VALIDATE step.
- **Tidy logs** — send Nextflow's run log to `.nextflow/` (via `NXF_LOG_FILE`, set on conda activate) so `.nextflow.log*` no longer clutter the repo root. There is no `nextflow.config` option for the log path since logging starts before the config is read.

## Test plan
- [ ] `nextflow run main.nf -profile test` — runs end-to-end on the stubs
- [ ] `nextflow run main.nf --input ../../data/9CFN_clean.cif` and `nextflow run main.nf ../../data/9CFN_clean.cif` — both forms resolve the input
- [ ] no `.nextflow.log*` appears in the repo root after a run (log lands in `.nextflow/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)