### PR TITLE
Add main.nf and env.yml for RNApolis module.

### DIFF
--- a/workstreams/ws1-annotation-validation/modules/rnapolis/.gitignore
+++ b/workstreams/ws1-annotation-validation/modules/rnapolis/.gitignore
@@ -1,0 +1,2 @@
+./work
+./results

--- a/workstreams/ws1-annotation-validation/modules/rnapolis/env.yml
+++ b/workstreams/ws1-annotation-validation/modules/rnapolis/env.yml
@@ -1,0 +1,10 @@
+# T2 annotator: RNApolis (annotator emits JSON). Selected when 'rnapolis' is in --annotators.
+name: ws1-rnapolis
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python>=3.10
+  - pip
+  - pip:
+      - rnapolis==0.16.7

--- a/workstreams/ws1-annotation-validation/modules/rnapolis/main.nf
+++ b/workstreams/ws1-annotation-validation/modules/rnapolis/main.nf
@@ -1,0 +1,33 @@
+#!/usr/bin/env nextflow
+
+// At the top of your main.nf file
+log.info "The project directory is: ${projectDir}"
+
+process RNApolisAnnotate {
+    tag "${structure.name}"
+    label 'annotation'
+    publishDir "${params.outdir}/annotation/rnapolis", mode: 'copy'
+    conda "env.yml"
+    
+    input:
+    path structure
+    
+    output:
+    path "${structure.simpleName}.csv", emit: base_pairs_csv
+    path "${structure.simpleName}.json", emit: base_pairs_json
+
+    script:
+    // Using a Nextflow variable to keep the bash block clean
+    def prefix = structure.simpleName
+    """
+    annotator --csv "${prefix}.csv" --json "${prefix}.json" --extended "${structure}"
+    """
+}
+
+workflow {    
+    // Ensure params.input is defined or fallback to avoid a null error
+    def input_path = params.input ?: 'data/*.cif.gz'
+    
+    structure_ch = Channel.fromPath(input_path, checkIfExists: true)
+    raw_ch       = RNApolisAnnotate( structure_ch )
+}


### PR DESCRIPTION
# Pull Request

## Summary
Nextflow module for generating RNApolis base pair annotation

- What does this PR change?
New module at: ws1-annotation-validation/modules/rnapolis
Includes: 
 -- main.nf: Process for generating RNApolis base pair annotation in json and csv format.
 -- env.yml: conda enviroment with rnapolis python package installed.

Call `RNApolisAnnotate` process in the main workflow at ws1-annotation-validation/main.nf  .


- Closes #45 


## Notes for reviewers

- All of pipeline runs correctly.
