### PR TITLE
Fix notation_to_cif: emit DNATCO-canonical LW labels and row order

### DIFF
--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/notation_to_cif.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/notation_to_cif.py
@@ -389,9 +389,37 @@ _ndb_base_pair_annotation.subclass
 """
 
 
+EDGE_PRIORITY = {"W": 0, "H": 1, "S": 2}        # canonical write order: W < H < S
+
+
+def _emit_sort_key(pair):
+    """Order pairs to match DNATCO's row layout: smaller chain ASC, smaller
+    residue ASC, then larger residue DESC. The descending tie-break puts the
+    farthest-reach pair first when two pairs share the same lower residue,
+    e.g. (5, 42, tWH) before (5, 26, tWS) in 9CFN."""
+    Ra, Rb, _ = pair
+    chain_a, _, num_a = Ra
+    chain_b, _, num_b = Rb
+    if (chain_a, num_a) > (chain_b, num_b):
+        chain_a, num_a, chain_b, num_b = chain_b, num_b, chain_a, num_a
+    return (chain_a, num_a, chain_b, -num_b)
+
+
 def emit_blocks(pairs, meta, oper_name_to_id) -> tuple[str, str]:
+    pairs = sorted(pairs, key=_emit_sort_key)
     list_rows, ann_rows = [], []
     for i, (Ra, Rb, lw) in enumerate(pairs, 1):
+        # DNATCO convention: in the row, the first residue carries the
+        # higher-priority edge (W < H < S). If our canonicalised pair has the
+        # priorities reversed (e.g. tHW, cSW, tSH), swap the residues and flip
+        # the LW string so it lands as tWH, cWS, tHS, ...  This is purely the
+        # output-order convention; the underlying pair is unchanged.
+        if (lw and len(lw) == 3 and lw[1] in EDGE_PRIORITY
+                and lw[2] in EDGE_PRIORITY
+                and EDGE_PRIORITY[lw[1]] > EDGE_PRIORITY[lw[2]]):
+            Ra, Rb = Rb, Ra
+            lw = _flip_lw(lw)
+
         ch1, s1, n1 = Ra
         ch2, s2, n2 = Rb
         m1 = meta.get((ch1, n1), {})


### PR DESCRIPTION
I added two small fixes to `emit_blocks` in `notation_to_cif.py`. First, the LW family
  string is now normalised to the W < H < S edge priority before writing, so
  the row carries `tWH` not `tHW`, `tWS` not `tSW`, etc., and the two residue
  positions in the row are swapped to match (the higher-priority edge comes
  first), so the `base_1_edge` / `base_2_edge` columns line up the same way
  DNATCO writes them.

  Second, the row order now matches DNATCO. Pairs are emitted by
  (smaller residue ASC, larger residue DESC) within a chain, so when two pairs
  share the same lower residue the longer-reach one comes first, fixing the
  9CFN pair 4 / pair 5 swap Maciej spotted. The pair set is unchanged
  (round-trip still True on all 7 DNATCO CIFs I tested), and the rebuilt CIF
  now matches DNATCO byte-for-byte on the list and annotation blocks of 9CFN.