### PR TITLE
Restore rnapolis and FR3D annotator implementation in ws1-annotate

### DIFF
--- a/workstreams/ws1-annotation-validation/bin/ws1-annotate
+++ b/workstreams/ws1-annotation-validation/bin/ws1-annotate
@@ -1,35 +1,71 @@
 #!/usr/bin/env python3
-"""WS1 skeleton STUB — Annotator (T2 tool).
+"""WS1 Annotator — runs FR3D or RNApolis on an mmCIF structure.
 
 Contract (do not change; the Nextflow ANNOTATE process depends on it):
     ws1-annotate --tool <name> --structure <structure.cif> --out <prefix>
-    => writes <prefix>.<ext>   (this stub writes <prefix>.json)
-
-Annotation team: replace the body with the real tool (FR3D, RNApolis, RNAview,
-NApair, ...). The tool's native output is fine; the matching ws1-parse handles it.
-This stub emits an empty annotation payload so the skeleton runs end-to-end.
+    Output:
+      rnapolis -> <prefix>.json   (rnapolis JSON with base_pairs list)
+      fr3d     -> <prefix>.tsv    (FR3D tab-separated pairs)
 """
 import argparse
-import json
+import subprocess
 import sys
 from pathlib import Path
 
 
-def main():
-    ap = argparse.ArgumentParser(description="WS1 annotator (stub)")
-    ap.add_argument("--tool", required=True)
-    ap.add_argument("--structure", required=True)
-    ap.add_argument("--out", required=True)
+def run_rnapolis(structure: Path, out_prefix: str) -> Path:
+    out = Path(f"{out_prefix}.json")
+    subprocess.run(
+        ["annotator", "--json", str(out), str(structure)],
+        check=True,
+    )
+    return out
+
+
+def run_fr3d(structure: Path, out_prefix: str) -> Path:
+    pdb_id = structure.stem
+    out_dir = Path(out_prefix).parent.resolve()
+
+    subprocess.run(
+        [
+            "python", "-m", "fr3d.classifiers.NA_pairwise_interactions",
+            "-i", str(structure.parent.resolve()),
+            "-o", str(out_dir),
+            structure.name,
+        ],
+        check=True,
+    )
+
+    out = Path(f"{out_prefix}.tsv")
+    (out_dir / f"{pdb_id}_basepair.txt").rename(out)
+    return out
+
+
+HANDLERS = {
+    "rnapolis": run_rnapolis,
+    "fr3d":     run_fr3d,
+}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="WS1 annotator")
+    ap.add_argument("--tool",      required=True)
+    ap.add_argument("--structure", required=True, type=Path)
+    ap.add_argument("--out",       required=True)
     args = ap.parse_args()
 
-    payload = {
-        "tool": args.tool,
-        "structure": Path(args.structure).name,
-        "base_pairs": [],  # stub: real annotators fill this in
-    }
-    out = f"{args.out}.json"
-    Path(out).write_text(json.dumps(payload, indent=2) + "\n")
-    print(f"[ws1-annotate:{args.tool}] {args.structure} -> {out}", file=sys.stderr)
+    structure = Path(args.structure)
+    if not structure.exists():
+        sys.exit(f"[ws1-annotate] structure not found: {structure}")
+
+    if args.tool not in HANDLERS:
+        sys.exit(
+            f"[ws1-annotate] unknown tool '{args.tool}'; "
+            f"supported: {', '.join(HANDLERS)}"
+        )
+
+    out = HANDLERS[args.tool](structure, args.out)
+    print(f"[ws1-annotate:{args.tool}] {structure} -> {out}", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Summary

Restored rnapolis and FR3D annotator implementation in bin/ws1-annotate that was accidentally reverted. Implements run_rnapolis calling the rnapolis annotator (JSON output) and run_fr3d calling FR3D (TSV output).

## Related issue(s)

- Closes #

## Checklist

- [x] I avoided including personal data or secrets
- [x] I updated docs if needed
- [ ] I tested/ran the relevant command(s) (if applicable)

## Notes for reviewers

- Anything you'd like reviewers to focus on?
