### PR TITLE
Add --unpaired flag: list residues with no hydrogen-bond partner

### DIFF
--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/common.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/common.py
@@ -253,6 +253,35 @@ def _family_of(label: str) -> str:
     return parts[1] if len(parts) >= 2 and parts[0].startswith("L") else parts[0]
 
 
+def _format_unpaired(unpaired: list, strands: list[tuple[str, str]]) -> str:
+    """ 'A8, A11, A29-32, A44, ...' -- compact comma-separated list of unpaired
+    residues, with consecutive numbers within one strand collapsed to ranges.
+    Symmetry mates use the same residue-with-bracketed-operator form as
+    _res_id (e.g. 'A2[2_565]' for a single residue, 'A2-5[2_565]' for a range).
+    Returns '(none)' when there are no unpaired residues."""
+    if not unpaired:
+        return "(none)"
+    by_strand: dict[tuple, list[int]] = {}
+    for ch, sym, num in unpaired:
+        by_strand.setdefault((ch, sym), []).append(num)
+    out: list[str] = []
+    for s in strands:
+        nums = sorted(by_strand.get(s, []))
+        if not nums:
+            continue
+        ch, sym = s
+        op_suffix = "" if sym == IDENTITY else f"[{sym}]"
+        i = 0
+        while i < len(nums):
+            j = i
+            while j + 1 < len(nums) and nums[j + 1] == nums[j] + 1:
+                j += 1
+            out.append(f"{ch}{nums[i]}{op_suffix}" if i == j
+                       else f"{ch}{nums[i]}-{nums[j]}{op_suffix}")
+            i = j + 1
+    return ", ".join(out)
+
+
 def _res_id(R: tuple) -> str:
     """Compact residue label: chain+number, with the operator only when it is a
     symmetry mate (e.g. 'A24', or 'A1012[2_755]')."""
@@ -273,7 +302,8 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
                    name: str = "RNA",
                    block: int | None = None, compact: bool = False,
                    noncanonical: bool = False, show_layer: bool = False,
-                   show_metadata: bool = False) -> tuple[str, bool]:
+                   show_metadata: bool = False,
+                   show_unpaired: bool = False) -> tuple[str, bool]:
     """Build the layered notation and return (text, round-trip ok).
 
     Args:
@@ -290,6 +320,13 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
         noncanonical: drop true Watson-Crick pairs entirely (the WC layer
             becomes absent). cWW U-U / U-G wobbles still appear on the cWW row.
         show_layer: prepend slot numbers ('L0 WC', 'L1 cWW', 'L10 tWW', ...).
+        show_unpaired: add a '# unpaired (N): A8, A11, A29-32, ...' comment
+            line below the header listing residues that have no hydrogen-bond
+            partner in the structure. Consecutive numbers within a strand are
+            collapsed to ranges. The count is a structural property and stays
+            the same regardless of --noncanonical: a stem residue that pairs
+            only via WC is still paired in the structure, its pair is just
+            hidden from the display.
         show_metadata: add a '# chains: ...' comment line below the header
             with per-strand chain/symmetry/range info.
 
@@ -305,6 +342,11 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
     strand is a symmetry mate (not the identity 1_555)."""
     base_of = {(ch, num): letter
                for ch, lst in per_chain.items() for num, letter in lst}
+
+    # Structural pairing snapshot, taken BEFORE the noncanonical display filter.
+    # Used by show_unpaired so that residues paired only via WC are not falsely
+    # reported as unpaired just because --noncanonical hid their pair from view.
+    full_paired_keys = {R for Ra, Rb, _ in pairs for R in (Ra, Rb)}
 
     if noncanonical:
         pairs = [p for p in pairs
@@ -380,6 +422,13 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
     if show_metadata:
         spans = ", ".join(f"{_label(s)}({_span(residues, s)})" for s in strands)
         head += f"\n# chains: {spans}; '{SEP}' separates chains"
+    if show_unpaired:
+        # Residues that have no hydrogen-bond partner in the FULL structure.
+        # We use the pre-filter pair set so the count is a structural property
+        # of the molecule, independent of --noncanonical (residues paired only
+        # via Watson-Crick are still paired -- their pair is just hidden).
+        unpaired = [R for R in residues if R not in full_paired_keys]
+        head += f"\n# unpaired ({len(unpaired)}): {_format_unpaired(unpaired, strands)}"
 
     if compact:        # only the canonical WC layer stays as dot-bracket; every
         rows = [f"{'seq':12}: " + seq_line]   # non-canonical layer becomes a

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/layered_basepairs.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/layered_basepairs.py
@@ -17,12 +17,16 @@ This file owns the FR3D-specific reading (unit-id parsing, pair list); the rest
 helpers -- lives in common.py.
 
 Usage:
-    python3 layered_basepairs.py <cif> <tsv> <chains...> [--name NAME]
+    python3 layered_basepairs.py <cif> <tsv> [chains...] [--name NAME]
                                   [--block N] [--compact] [--noncanonical]
                                   [--layer] [--metadata]
 
+With no chains, all chains present in the FR3D TSV are used automatically.
+
 Examples (mmCIF from files.rcsb.org/download/<ID>.cif, basepairs TSV from FR3D):
     python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv A --name 9CFN
+    # no chains given -> all chains in the TSV are used
+    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv --name 9CFN
     python3 layered_basepairs.py 1XPE.cif 1xpe_fr3d_basepairs.tsv A B --name 1XPE
     python3 layered_basepairs.py 2Q1R.cif 2q1r_fr3d_basepairs.tsv A --name 2Q1R
 
@@ -49,6 +53,21 @@ def _sym(unit: list[str]) -> str:
     reported explicitly as 1_555. FR3D unit id format is
     pdb|model|chain|comp|num|atom|alt|ins|symmetry."""
     return unit[8] if len(unit) > 8 and unit[8] else IDENTITY
+
+
+def list_chains(tsv: Path) -> list[str]:
+    """Chains that appear in the FR3D pair list, sorted. Used as the default
+    when no chains are given on the command line."""
+    chains: set[str] = set()
+    for line in tsv.read_text().splitlines():
+        c = line.strip().split("\t")
+        if len(c) < 3:
+            continue
+        a, b = c[0].split("|"), c[2].split("|")
+        if len(a) > 2 and len(b) > 2:
+            chains.add(a[2])
+            chains.add(b[2])
+    return sorted(chains)
 
 
 def read_pairs(tsv: Path, chains: set[str]) -> list[tuple[tuple, tuple, str]]:
@@ -80,8 +99,9 @@ if __name__ == "__main__":
                     "(symmetry-aware), driven by an FR3D base-pair TSV.")
     ap.add_argument("cif", type=Path, help="mmCIF file (sequence + residue numbers)")
     ap.add_argument("tsv", type=Path, help="FR3D basepairs TSV")
-    ap.add_argument("chains", nargs="+",
-                    help="chain ids, in the order to lay them on the ruler")
+    ap.add_argument("chains", nargs="*",
+                    help="chain ids, in the order to lay them on the ruler; "
+                         "default: all chains present in the TSV")
     ap.add_argument("--name", default="RNA", help="label for the header line")
     ap.add_argument("--block", type=int, nargs="?", const=BLOCK, default=None,
                     help=f"wrap lines into blocks of this many columns "
@@ -100,14 +120,20 @@ if __name__ == "__main__":
     ap.add_argument("--metadata", action="store_true",
                     help="add a '# chains: ...' comment line below the header "
                          "with per-strand chain/symmetry/range info; off by default")
+    ap.add_argument("--unpaired", action="store_true",
+                    help="add a '# unpaired (N): A8, A11, A29-32, ...' comment "
+                         "line below the header listing residues that "
+                         "participate in no displayed pair; off by default")
     a = ap.parse_args()
 
-    per_chain = read_residues(a.cif, a.chains)
-    pairs = read_pairs(a.tsv, set(a.chains))
-    text, ok = build_notation(per_chain, pairs, a.chains, name=a.name,
+    chains = a.chains or list_chains(a.tsv)
+    per_chain = read_residues(a.cif, chains)
+    pairs = read_pairs(a.tsv, set(chains))
+    text, ok = build_notation(per_chain, pairs, chains, name=a.name,
                               block=a.block, compact=a.compact,
                               noncanonical=a.noncanonical,
-                              show_layer=a.layer, show_metadata=a.metadata)
+                              show_layer=a.layer, show_metadata=a.metadata,
+                              show_unpaired=a.unpaired)
     print(text)
     print(f"\n# round-trip recovers all pairs exactly: {ok}", file=sys.stderr)
     sys.exit(0 if ok else 1)

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/standalone_lbn_script.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/standalone_lbn_script.py
@@ -293,6 +293,10 @@ def main() -> None:
                     help="add a '# chains: ...' comment line below the header "
                          "with per-strand chain/symmetry/range info "
                          "(e.g. 'A[1_555](1-59)'); off by default")
+    ap.add_argument("--unpaired", action="store_true",
+                    help="add a '# unpaired (N): A8, A11, A29-32, ...' comment "
+                         "line below the header listing residues that "
+                         "participate in no displayed pair; off by default")
     ap.add_argument("--script", metavar="FILE",
                     help="write the iCn3D commands to FILE (one per line) to "
                          "load via File > Open File > State/Script File, "
@@ -306,7 +310,8 @@ def main() -> None:
     pairs = read_pairs(a.cif, set(chains))
     text, ok = build_notation(per_chain, pairs, chains, name=a.name, block=a.block,
                               compact=a.compact, noncanonical=a.noncanonical,
-                              show_layer=a.layer, show_metadata=a.metadata)
+                              show_layer=a.layer, show_metadata=a.metadata,
+                              show_unpaired=a.unpaired)
     print(text)
     print(f"\n# round-trip recovers all pairs exactly: {ok}", file=sys.stderr)
 


### PR DESCRIPTION
Adds a `--unpaired` flag to both forward scripts. It emits a `#`-prefixed
  comment line below the header listing the residues that have no
  hydrogen-bond partner in the structure, with consecutive numbers within a
  strand collapsed to ranges:
  
      >9HRF|A
      # unpaired (13): A8, A11, A29-32, A44, A49-51, A61, A69-70
      seq         : GGGCGCAUUUUGGUAGGUCGGUCGCUGCUUCGGCAGUGAGGGGUAGGCAUUGCUGGCCUAGGGUGCCCUU
      WC          : ((((.(...(...[[[[.[.[((.((((....)))).)).....)..(...)].].]]]]..).))))..
      ...

  

  Symmetry mates use the same `chain<num>[<operator>]` notation the rest of
  the script uses (e.g. `A2[2_565]`), so 8VJT prints

      # unpaired (8): A2, A2[2_565], A2[3_555], A2[4_455], B2, B2[2_565], B2[3_555], B2[4_455]



  ## Tested on

  8XZN (10 unpaired), 9HRF (13), 8BWT (2), 8VJT (8 with symmetry mates), in
  default / `--compact` / `--layer` / `--metadata` / `--noncanonical` modes.
  Round-trip via `notation_to_cif.py` stays True (the inverse already skips
  `#`-prefixed lines), and re-deriving the notation from the rebuilt CIF is
  byte-identical.

  