### PR TITLE
--unpaired: prefer _ndb_base_unpaired_list from the CIF when present, derive otherwise

### DIFF
--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/common.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/common.py
@@ -303,7 +303,9 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
                    block: int | None = None, compact: bool = False,
                    noncanonical: bool = False, show_layer: bool = False,
                    show_metadata: bool = False,
-                   show_unpaired: bool = False) -> tuple[str, bool]:
+                   show_unpaired: bool = False,
+                   explicit_unpaired: list | None = None,
+                   unpaired_source: str = "") -> tuple[str, bool]:
     """Build the layered notation and return (text, round-trip ok).
 
     Args:
@@ -327,6 +329,15 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
             the same regardless of --noncanonical: a stem residue that pairs
             only via WC is still paired in the structure, its pair is just
             hidden from the display.
+        explicit_unpaired: when given, use this list of residues directly
+            instead of deriving the unpaired set from `pairs`. Each entry is
+            (chain, symmetry, number). The caller passes this when the CIF
+            ships its own _ndb_base_unpaired_list annotation, which is the
+            authoritative source for NMR ensembles where the unpaired set
+            varies across models.
+        unpaired_source: short tag appended to the '# unpaired' line to record
+            where the list came from (e.g. 'from _ndb_base_unpaired_list,
+            model 1'). Only printed when non-empty.
         show_metadata: add a '# chains: ...' comment line below the header
             with per-strand chain/symmetry/range info.
 
@@ -423,12 +434,18 @@ def build_notation(per_chain: dict[str, list], pairs: list, chains: list[str],
         spans = ", ".join(f"{_label(s)}({_span(residues, s)})" for s in strands)
         head += f"\n# chains: {spans}; '{SEP}' separates chains"
     if show_unpaired:
-        # Residues that have no hydrogen-bond partner in the FULL structure.
-        # We use the pre-filter pair set so the count is a structural property
-        # of the molecule, independent of --noncanonical (residues paired only
-        # via Watson-Crick are still paired -- their pair is just hidden).
-        unpaired = [R for R in residues if R not in full_paired_keys]
-        head += f"\n# unpaired ({len(unpaired)}): {_format_unpaired(unpaired, strands)}"
+        # Prefer the caller-supplied explicit list (e.g. read directly from
+        # _ndb_base_unpaired_list) since it is authoritative for NMR ensembles;
+        # otherwise derive from the pre-filter pair set so the count is a
+        # structural property of the molecule, independent of --noncanonical
+        # (a residue paired only via Watson-Crick is still paired -- the pair
+        # is just hidden when --noncanonical drops the WC layer).
+        if explicit_unpaired is not None:
+            unpaired = sorted(explicit_unpaired)
+        else:
+            unpaired = [R for R in residues if R not in full_paired_keys]
+        tag = f"  [{unpaired_source}]" if unpaired_source else ""
+        head += f"\n# unpaired ({len(unpaired)}): {_format_unpaired(unpaired, strands)}{tag}"
 
     if compact:        # only the canonical WC layer stays as dot-bracket; every
         rows = [f"{'seq':12}: " + seq_line]   # non-canonical layer becomes a

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/layered_basepairs.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/layered_basepairs.py
@@ -133,7 +133,9 @@ if __name__ == "__main__":
                               block=a.block, compact=a.compact,
                               noncanonical=a.noncanonical,
                               show_layer=a.layer, show_metadata=a.metadata,
-                              show_unpaired=a.unpaired)
+                              show_unpaired=a.unpaired,
+                              unpaired_source=("derived from FR3D pair list"
+                                               if a.unpaired else ""))
     print(text)
     print(f"\n# round-trip recovers all pairs exactly: {ok}", file=sys.stderr)
     sys.exit(0 if ok else 1)

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/standalone_lbn_script.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/standalone_lbn_script.py
@@ -123,6 +123,34 @@ def read_pairs(cif: Path, chains: set[str]) -> list[tuple[tuple, tuple, str]]:
     return sorted(seen.values())
 
 
+def read_unpaired_list(cif: Path, chains: set[str],
+                       model: int = 1) -> list[tuple] | None:
+    """Residues marked unpaired by _ndb_base_unpaired_list for the given model,
+    as [(chain, IDENTITY, num), ...]. Returns None if the category is absent
+    (caller then derives the set from the pair list). DNATCO's annotation is
+    the authoritative source for NMR ensembles, where the unpaired set varies
+    across models; we default to model 1, matching the single-conformer
+    convention used elsewhere in this script (asymmetric unit, _atom_site,
+    coordinates). Symmetry mates never appear here -- the category lives in
+    label space, asymmetric unit only."""
+    lines = cif.read_text().splitlines()
+    if not any(l.startswith("_ndb_base_unpaired_list.") for l in lines):
+        return None
+    idx, i = _loop_columns(lines, "_ndb_base_unpaired_list.")
+    if not idx:
+        return None
+    c_model = idx.get("PDB_model_num")
+    c_ch, c_num = idx["auth_asym_id"], idx["auth_seq_id"]
+    out: list[tuple] = []
+    for row in _read_loop_rows(lines, i, len(idx)):
+        if c_model is not None and row[c_model] != str(model):
+            continue
+        ch = row[c_ch]
+        if ch in chains:
+            out.append((ch, IDENTITY, int(row[c_num])))
+    return out
+
+
 def list_chains(cif: Path) -> list[str]:
     """Chains that appear in the base-pair list, sorted. Used when no chains
     are given; these are exactly the nucleic-acid chains that form annotated
@@ -305,13 +333,25 @@ def main() -> None:
 
     chains = a.chains or list_chains(a.cif)
 
-    # 1) notation -- caller does the CIF reads, common.py does the layering
+    # 1) notation -- caller does the CIF reads, common.py does the layering.
+    # Unpaired list: if the CIF ships _ndb_base_unpaired_list (DNATCO's own
+    # per-model annotation), trust it -- otherwise common.py derives the set
+    # from the pair list.
     per_chain = read_residues(a.cif, chains)
     pairs = read_pairs(a.cif, set(chains))
+    explicit_unpaired, unpaired_source = None, ""
+    if a.unpaired:
+        explicit_unpaired = read_unpaired_list(a.cif, set(chains))
+        if explicit_unpaired is not None:
+            unpaired_source = "from _ndb_base_unpaired_list, model 1"
+        else:
+            unpaired_source = "derived from pair list"
     text, ok = build_notation(per_chain, pairs, chains, name=a.name, block=a.block,
                               compact=a.compact, noncanonical=a.noncanonical,
                               show_layer=a.layer, show_metadata=a.metadata,
-                              show_unpaired=a.unpaired)
+                              show_unpaired=a.unpaired,
+                              explicit_unpaired=explicit_unpaired,
+                              unpaired_source=unpaired_source)
     print(text)
     print(f"\n# round-trip recovers all pairs exactly: {ok}", file=sys.stderr)
 


### PR DESCRIPTION
## What this changes

  `--unpaired` now decides where to get the unpaired-residue list using a
  simple rule: 

  - **If the CIF has `_ndb_base_unpaired_list`** → read it directly
    (default: model 1). DNATCO's own annotation is the authoritative source,
    especially for NMR ensembles where the unpaired set varies per model.
  - **If the CIF does not have that category** → derive it from
    `_ndb_base_pair_list`: every residue in the chain that never appears in
    any pair row is unpaired. (FR3D-driven script always derives, since FR3D
    only provides a pair list.)