### PR TITLE
--unpaired source from CIF when present; --name auto-detected; refreshed docs + 8VJT example

### DIFF
--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/8VJT.cif
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/8VJT.cif
@@ -1,0 +1,3651 @@
+data_8VJT
+_entry.id                         8VJT
+
+_audit_conform.dict_name          mmcif_pdbx.dic
+_audit_conform.dict_version       5.399
+_audit_conform.dict_location      http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic
+
+loop_
+_database_2.database_id
+_database_2.database_code
+_database_2.pdbx_database_accession
+_database_2.pdbx_DOI
+PDB   8VJT         pdb_00008vjt 10.2210/pdb8vjt/pdb
+WWPDB D_1000280407 ?            ?
+
+loop_
+_pdbx_audit_revision_history.ordinal
+_pdbx_audit_revision_history.data_content_type
+_pdbx_audit_revision_history.major_revision
+_pdbx_audit_revision_history.minor_revision
+_pdbx_audit_revision_history.revision_date
+1 'Structure model' 1 0 2024-10-16
+2 'Structure model' 1 1 2024-11-27
+
+_pdbx_audit_revision_details.ordinal 1
+_pdbx_audit_revision_details.revision_ordinal 1
+_pdbx_audit_revision_details.data_content_type 'Structure model'
+_pdbx_audit_revision_details.provider repository
+_pdbx_audit_revision_details.type 'Initial release'
+_pdbx_audit_revision_details.description ?
+_pdbx_audit_revision_details.details ?
+
+_pdbx_audit_revision_group.ordinal 1
+_pdbx_audit_revision_group.revision_ordinal 2
+_pdbx_audit_revision_group.data_content_type 'Structure model'
+_pdbx_audit_revision_group.group  'Database references'
+
+loop_
+_pdbx_audit_revision_category.ordinal
+_pdbx_audit_revision_category.revision_ordinal
+_pdbx_audit_revision_category.data_content_type
+_pdbx_audit_revision_category.category
+1 2 'Structure model' citation
+2 2 'Structure model' citation_author
+
+loop_
+_pdbx_audit_revision_item.ordinal
+_pdbx_audit_revision_item.revision_ordinal
+_pdbx_audit_revision_item.data_content_type
+_pdbx_audit_revision_item.item
+1 2 'Structure model' '_citation.journal_volume'
+2 2 'Structure model' '_citation.page_first'
+3 2 'Structure model' '_citation.page_last'
+4 2 'Structure model' '_citation_author.identifier_ORCID'
+
+_pdbx_database_status.status_code REL
+_pdbx_database_status.status_code_sf REL
+_pdbx_database_status.status_code_mr ?
+_pdbx_database_status.entry_id    8VJT
+_pdbx_database_status.recvd_initial_deposition_date 2024-01-08
+_pdbx_database_status.SG_entry    N
+_pdbx_database_status.deposit_site RCSB
+_pdbx_database_status.process_site RCSB
+_pdbx_database_status.status_code_cs ?
+_pdbx_database_status.status_code_nmr_data ?
+_pdbx_database_status.methods_development_category ?
+_pdbx_database_status.pdb_format_compatible Y
+
+_pdbx_contact_author.id           2
+_pdbx_contact_author.email        sebutcher@wisc.edu
+_pdbx_contact_author.name_first   Samuel
+_pdbx_contact_author.name_last    Butcher
+_pdbx_contact_author.name_mi      E
+_pdbx_contact_author.role         'principal investigator/group leader'
+_pdbx_contact_author.identifier_ORCID 0000-0001-6343-6643
+
+loop_
+_audit_author.name
+_audit_author.pdbx_ordinal
+_audit_author.identifier_ORCID
+'Bingman, C.A.'    1 0000-0002-3073-5089
+'Montemayor, E.J.' 2 0000-0001-7883-7706
+'Roschdi, S.'      3 0000-0001-6360-6868
+'Nomura, Y.'       4 0000-0002-8275-4468
+'Butcher, S.E.'    5 0000-0001-6343-6643
+
+_citation.abstract                ?
+_citation.abstract_id_CAS         ?
+_citation.book_id_ISBN            ?
+_citation.book_publisher          ?
+_citation.book_publisher_city     ?
+_citation.book_title              ?
+_citation.coordinate_linkage      ?
+_citation.country                 UK
+_citation.database_id_Medline     ?
+_citation.details                 ?
+_citation.id                      primary
+_citation.journal_abbrev          'Nucleic Acids Res.'
+_citation.journal_id_ASTM         NARHAD
+_citation.journal_id_CSD          0389
+_citation.journal_id_ISSN         1362-4962
+_citation.journal_full            ?
+_citation.journal_issue           ?
+_citation.journal_volume          52
+_citation.language                ?
+_citation.page_first              12582
+_citation.page_last               12591
+_citation.title                   'Self-assembly and condensation of intermolecular poly(UG) RNA quadruplexes.'
+_citation.year                    2024
+_citation.database_id_CSD         ?
+_citation.pdbx_database_id_DOI    10.1093/nar/gkae870
+_citation.pdbx_database_id_PubMed 39373474
+_citation.pdbx_database_id_patent ?
+_citation.unpublished_flag        ?
+
+loop_
+_citation_author.citation_id
+_citation_author.name
+_citation_author.ordinal
+_citation_author.identifier_ORCID
+primary 'Roschdi, S.'      1 ?
+primary 'Montemayor, E.J.' 2 ?
+primary 'Vivek, R.'        3 ?
+primary 'Bingman, C.A.'    4 ?
+primary 'Butcher, S.E.'    5 ?
+
+loop_
+_entity.id
+_entity.type
+_entity.src_method
+_entity.pdbx_description
+_entity.formula_weight
+_entity.pdbx_number_of_molecules
+_entity.pdbx_ec
+_entity.pdbx_mutation
+_entity.pdbx_fragment
+_entity.details
+1 polymer     syn "RNA(5'-R(*GP*UP*GP*UP*GP*U)-3')" 1909.157 2  ? ? ? ?
+2 non-polymer syn 'POTASSIUM ION'                39.098   7  ? ? ? ?
+3 non-polymer syn 'SODIUM ION'                   22.990   2  ? ? ? ?
+4 water       nat water                          18.015   39 ? ? ? ?
+
+_entity_poly.entity_id            1
+_entity_poly.type                 polyribonucleotide
+_entity_poly.nstd_linkage         no
+_entity_poly.nstd_monomer         no
+_entity_poly.pdbx_seq_one_letter_code GUGUGU
+_entity_poly.pdbx_seq_one_letter_code_can GUGUGU
+_entity_poly.pdbx_strand_id       A,B
+_entity_poly.pdbx_target_identifier ?
+
+loop_
+_pdbx_entity_nonpoly.entity_id
+_pdbx_entity_nonpoly.name
+_pdbx_entity_nonpoly.comp_id
+2 'POTASSIUM ION' K
+3 'SODIUM ION'    NA
+4 water           HOH
+
+loop_
+_entity_poly_seq.entity_id
+_entity_poly_seq.num
+_entity_poly_seq.mon_id
+_entity_poly_seq.hetero
+1 1 G n
+1 2 U n
+1 3 G n
+1 4 U n
+1 5 G n
+1 6 U n
+
+_pdbx_entity_src_syn.entity_id    1
+_pdbx_entity_src_syn.pdbx_src_id  1
+_pdbx_entity_src_syn.pdbx_alt_source_flag sample
+_pdbx_entity_src_syn.pdbx_beg_seq_num 1
+_pdbx_entity_src_syn.pdbx_end_seq_num 6
+_pdbx_entity_src_syn.organism_scientific 'synthetic construct'
+_pdbx_entity_src_syn.organism_common_name ?
+_pdbx_entity_src_syn.ncbi_taxonomy_id 32630
+_pdbx_entity_src_syn.details      ?
+
+loop_
+_chem_comp.id
+_chem_comp.type
+_chem_comp.mon_nstd_flag
+_chem_comp.name
+_chem_comp.pdbx_synonyms
+_chem_comp.formula
+_chem_comp.formula_weight
+G   'RNA linking' y "GUANOSINE-5'-MONOPHOSPHATE" ? 'C10 H14 N5 O8 P' 363.221
+HOH non-polymer   . WATER                        ? 'H2 O'            18.015
+K   non-polymer   . 'POTASSIUM ION'              ? 'K 1'             39.098
+NA  non-polymer   . 'SODIUM ION'                 ? 'Na 1'            22.990
+U   'RNA linking' y "URIDINE-5'-MONOPHOSPHATE"   ? 'C9 H13 N2 O9 P'  324.181
+
+loop_
+_pdbx_poly_seq_scheme.asym_id
+_pdbx_poly_seq_scheme.entity_id
+_pdbx_poly_seq_scheme.seq_id
+_pdbx_poly_seq_scheme.mon_id
+_pdbx_poly_seq_scheme.ndb_seq_num
+_pdbx_poly_seq_scheme.pdb_seq_num
+_pdbx_poly_seq_scheme.auth_seq_num
+_pdbx_poly_seq_scheme.pdb_mon_id
+_pdbx_poly_seq_scheme.auth_mon_id
+_pdbx_poly_seq_scheme.pdb_strand_id
+_pdbx_poly_seq_scheme.pdb_ins_code
+_pdbx_poly_seq_scheme.hetero
+A 1 1 G 1 1 1 G G A . n
+A 1 2 U 2 2 2 U U A . n
+A 1 3 G 3 3 3 G G A . n
+A 1 4 U 4 4 4 U U A . n
+A 1 5 G 5 5 5 G G A . n
+A 1 6 U 6 6 6 U U A . n
+B 1 1 G 1 1 1 G G B . n
+B 1 2 U 2 2 2 U U B . n
+B 1 3 G 3 3 3 G G B . n
+B 1 4 U 4 4 4 U U B . n
+B 1 5 G 5 5 5 G G B . n
+B 1 6 U 6 6 6 U U B . n
+
+loop_
+_pdbx_entity_instance_feature.ordinal
+_pdbx_entity_instance_feature.comp_id
+_pdbx_entity_instance_feature.asym_id
+_pdbx_entity_instance_feature.seq_num
+_pdbx_entity_instance_feature.auth_comp_id
+_pdbx_entity_instance_feature.auth_asym_id
+_pdbx_entity_instance_feature.auth_seq_num
+_pdbx_entity_instance_feature.feature_type
+_pdbx_entity_instance_feature.details
+1 K  ? ? K  ? ? 'SUBJECT OF INVESTIGATION' ?
+2 NA ? ? NA ? ? 'SUBJECT OF INVESTIGATION' ?
+
+loop_
+_pdbx_nonpoly_scheme.asym_id
+_pdbx_nonpoly_scheme.entity_id
+_pdbx_nonpoly_scheme.mon_id
+_pdbx_nonpoly_scheme.ndb_seq_num
+_pdbx_nonpoly_scheme.pdb_seq_num
+_pdbx_nonpoly_scheme.auth_seq_num
+_pdbx_nonpoly_scheme.pdb_mon_id
+_pdbx_nonpoly_scheme.auth_mon_id
+_pdbx_nonpoly_scheme.pdb_strand_id
+_pdbx_nonpoly_scheme.pdb_ins_code
+C 2 K   1  101 4  K   K   A .
+D 2 K   1  102 5  K   K   A .
+E 2 K   1  103 6  K   K   A .
+F 2 K   1  104 7  K   K   A .
+G 3 NA  1  105 1  NA  NA  A .
+H 2 K   1  101 1  K   K   B .
+I 2 K   1  102 2  K   K   B .
+J 2 K   1  103 3  K   K   B .
+K 3 NA  1  104 2  NA  NA  B .
+L 4 HOH 1  201 89 HOH HOH A .
+L 4 HOH 2  202 10 HOH HOH A .
+L 4 HOH 3  203 88 HOH HOH A .
+L 4 HOH 4  204 4  HOH HOH A .
+L 4 HOH 5  205 85 HOH HOH A .
+L 4 HOH 6  206 2  HOH HOH A .
+L 4 HOH 7  207 11 HOH HOH A .
+L 4 HOH 8  208 82 HOH HOH A .
+L 4 HOH 9  209 65 HOH HOH A .
+L 4 HOH 10 210 7  HOH HOH A .
+L 4 HOH 11 211 1  HOH HOH A .
+L 4 HOH 12 212 80 HOH HOH A .
+L 4 HOH 13 213 84 HOH HOH A .
+L 4 HOH 14 214 9  HOH HOH A .
+L 4 HOH 15 215 68 HOH HOH A .
+L 4 HOH 16 216 94 HOH HOH A .
+L 4 HOH 17 217 74 HOH HOH A .
+L 4 HOH 18 218 73 HOH HOH A .
+L 4 HOH 19 219 71 HOH HOH A .
+L 4 HOH 20 220 12 HOH HOH A .
+L 4 HOH 21 221 79 HOH HOH A .
+L 4 HOH 22 222 81 HOH HOH A .
+L 4 HOH 23 223 76 HOH HOH A .
+L 4 HOH 24 224 24 HOH HOH A .
+L 4 HOH 25 225 28 HOH HOH A .
+L 4 HOH 26 226 47 HOH HOH A .
+M 4 HOH 1  201 23 HOH HOH B .
+M 4 HOH 2  202 6  HOH HOH B .
+M 4 HOH 3  203 77 HOH HOH B .
+M 4 HOH 4  204 92 HOH HOH B .
+M 4 HOH 5  205 18 HOH HOH B .
+M 4 HOH 6  206 70 HOH HOH B .
+M 4 HOH 7  207 75 HOH HOH B .
+M 4 HOH 8  208 72 HOH HOH B .
+M 4 HOH 9  209 69 HOH HOH B .
+M 4 HOH 10 210 46 HOH HOH B .
+M 4 HOH 11 211 15 HOH HOH B .
+M 4 HOH 12 212 93 HOH HOH B .
+M 4 HOH 13 213 91 HOH HOH B .
+
+loop_
+_software.citation_id
+_software.classification
+_software.compiler_name
+_software.compiler_version
+_software.contact_author
+_software.contact_author_email
+_software.date
+_software.description
+_software.dependencies
+_software.hardware
+_software.language
+_software.location
+_software.mods
+_software.name
+_software.os
+_software.os_version
+_software.type
+_software.version
+_software.pdbx_ordinal
+? 'data processing' ? ? ? ? ? ? ? ? ? ? ? autoPROC ? ? ? '1.0.5 (20230726)' 1
+? 'data reduction'  ? ? ? ? ? ? ? ? ? ? ? XDS      ? ? ? 'Jun 30, 2023'     2
+? 'data scaling'    ? ? ? ? ? ? ? ? ? ? ? Aimless  ? ? ? 0.7.13             3
+? 'data processing' ? ? ? ? ? ? ? ? ? ? ? TRUNCATE ? ? ? 8.0.015            4
+? refinement        ? ? ? ? ? ? ? ? ? ? ? PHENIX   ? ? ? 1.20.1_4487        5
+? phasing           ? ? ? ? ? ? ? ? ? ? ? HKL2Map  ? ? ? .                  6
+
+_cell.angle_alpha                 90.000
+_cell.angle_alpha_esd             ?
+_cell.angle_beta                  90.000
+_cell.angle_beta_esd              ?
+_cell.angle_gamma                 90.000
+_cell.angle_gamma_esd             ?
+_cell.entry_id                    8VJT
+_cell.details                     ?
+_cell.formula_units_Z             ?
+_cell.length_a                    32.821
+_cell.length_a_esd                ?
+_cell.length_b                    32.821
+_cell.length_b_esd                ?
+_cell.length_c                    57.970
+_cell.length_c_esd                ?
+_cell.volume                      62446.330
+_cell.volume_esd                  ?
+_cell.Z_PDB                       16
+_cell.reciprocal_angle_alpha      ?
+_cell.reciprocal_angle_beta       ?
+_cell.reciprocal_angle_gamma      ?
+_cell.reciprocal_angle_alpha_esd  ?
+_cell.reciprocal_angle_beta_esd   ?
+_cell.reciprocal_angle_gamma_esd  ?
+_cell.reciprocal_length_a         ?
+_cell.reciprocal_length_b         ?
+_cell.reciprocal_length_c         ?
+_cell.reciprocal_length_a_esd     ?
+_cell.reciprocal_length_b_esd     ?
+_cell.reciprocal_length_c_esd     ?
+_cell.pdbx_unique_axis            ?
+_cell.pdbx_esd_method             ?
+
+_symmetry.entry_id                8VJT
+_symmetry.cell_setting            ?
+_symmetry.Int_Tables_number       90
+_symmetry.space_group_name_Hall   'P 4ab 2ab'
+_symmetry.space_group_name_H-M    'P 4 21 2'
+_symmetry.pdbx_full_space_group_name_H-M ?
+
+_exptl.absorpt_coefficient_mu     ?
+_exptl.absorpt_correction_T_max   ?
+_exptl.absorpt_correction_T_min   ?
+_exptl.absorpt_correction_type    ?
+_exptl.absorpt_process_details    ?
+_exptl.entry_id                   8VJT
+_exptl.crystals_number            1
+_exptl.details                    ?
+_exptl.method                     'X-RAY DIFFRACTION'
+_exptl.method_details             ?
+
+_exptl_crystal.colour             ?
+_exptl_crystal.density_diffrn     ?
+_exptl_crystal.density_Matthews   2.04
+_exptl_crystal.density_method     ?
+_exptl_crystal.density_percent_sol 39.83
+_exptl_crystal.description        ?
+_exptl_crystal.F_000              ?
+_exptl_crystal.id                 1
+_exptl_crystal.preparation        ?
+_exptl_crystal.size_max           ?
+_exptl_crystal.size_mid           ?
+_exptl_crystal.size_min           ?
+_exptl_crystal.size_rad           ?
+_exptl_crystal.colour_lustre      ?
+_exptl_crystal.colour_modifier    ?
+_exptl_crystal.colour_primary     ?
+_exptl_crystal.density_meas       ?
+_exptl_crystal.density_meas_esd   ?
+_exptl_crystal.density_meas_gt    ?
+_exptl_crystal.density_meas_lt    ?
+_exptl_crystal.density_meas_temp  ?
+_exptl_crystal.density_meas_temp_esd ?
+_exptl_crystal.density_meas_temp_gt ?
+_exptl_crystal.density_meas_temp_lt ?
+_exptl_crystal.pdbx_crystal_image_url ?
+_exptl_crystal.pdbx_crystal_image_format ?
+_exptl_crystal.pdbx_mosaicity     ?
+_exptl_crystal.pdbx_mosaicity_esd ?
+_exptl_crystal.pdbx_mosaic_method ?
+_exptl_crystal.pdbx_mosaic_block_size ?
+_exptl_crystal.pdbx_mosaic_block_size_esd ?
+
+_exptl_crystal_grow.apparatus     ?
+_exptl_crystal_grow.atmosphere    ?
+_exptl_crystal_grow.crystal_id    1
+_exptl_crystal_grow.details       ?
+_exptl_crystal_grow.method        'VAPOR DIFFUSION, SITTING DROP'
+_exptl_crystal_grow.method_ref    ?
+_exptl_crystal_grow.pH            6.5
+_exptl_crystal_grow.pressure      ?
+_exptl_crystal_grow.pressure_esd  ?
+_exptl_crystal_grow.seeding       ?
+_exptl_crystal_grow.seeding_ref   ?
+_exptl_crystal_grow.temp_details  ?
+_exptl_crystal_grow.temp_esd      ?
+_exptl_crystal_grow.time          ?
+_exptl_crystal_grow.pdbx_details
+"Diffractionquality crystals were eventually obtained by sitting drop vapor diffusion by mixing 2 uL of RNA with 2 uL of crystallization reagent containing 200 mM NaCl, 100 mM bis-tris pH 6.5 and 50 % PEG 550 MME. Crystals were vitrified by direct immersion into liquid nitrogen"
+_exptl_crystal_grow.pdbx_pH_range ?
+_exptl_crystal_grow.temp          298
+
+_diffrn.ambient_environment       ?
+_diffrn.ambient_temp              100
+_diffrn.ambient_temp_details      ?
+_diffrn.ambient_temp_esd          ?
+_diffrn.crystal_id                1
+_diffrn.crystal_support           ?
+_diffrn.crystal_treatment         ?
+_diffrn.details                   ?
+_diffrn.id                        1
+_diffrn.ambient_pressure          ?
+_diffrn.ambient_pressure_esd      ?
+_diffrn.ambient_pressure_gt       ?
+_diffrn.ambient_pressure_lt       ?
+_diffrn.ambient_temp_gt           ?
+_diffrn.ambient_temp_lt           ?
+_diffrn.pdbx_serial_crystal_experiment N
+
+_diffrn_detector.details          ?
+_diffrn_detector.detector         PIXEL
+_diffrn_detector.diffrn_id        1
+_diffrn_detector.type             'DECTRIS EIGER X 9M'
+_diffrn_detector.area_resol_mean  ?
+_diffrn_detector.dtime            ?
+_diffrn_detector.pdbx_frames_total ?
+_diffrn_detector.pdbx_collection_time_total ?
+_diffrn_detector.pdbx_collection_date 2018-11-09
+_diffrn_detector.pdbx_frequency   ?
+_diffrn_detector.id               ?
+_diffrn_detector.number_of_axes   ?
+
+_diffrn_radiation.collimation     ?
+_diffrn_radiation.diffrn_id       1
+_diffrn_radiation.filter_edge     ?
+_diffrn_radiation.inhomogeneity   ?
+_diffrn_radiation.monochromator   'Si(111)'
+_diffrn_radiation.polarisn_norm   ?
+_diffrn_radiation.polarisn_ratio  ?
+_diffrn_radiation.probe           ?
+_diffrn_radiation.type            ?
+_diffrn_radiation.xray_symbol     ?
+_diffrn_radiation.wavelength_id   1
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l M
+_diffrn_radiation.pdbx_wavelength_list ?
+_diffrn_radiation.pdbx_wavelength ?
+_diffrn_radiation.pdbx_diffrn_protocol 'SINGLE WAVELENGTH'
+_diffrn_radiation.pdbx_analyzer   ?
+_diffrn_radiation.pdbx_scattering_type x-ray
+
+_diffrn_radiation_wavelength.id   1
+_diffrn_radiation_wavelength.wavelength 0.97619
+_diffrn_radiation_wavelength.wt   1.0
+
+_diffrn_source.current            ?
+_diffrn_source.details            ?
+_diffrn_source.diffrn_id          1
+_diffrn_source.power              ?
+_diffrn_source.size               ?
+_diffrn_source.source             SYNCHROTRON
+_diffrn_source.target             ?
+_diffrn_source.type               'APS BEAMLINE 21-ID-D'
+_diffrn_source.voltage            ?
+_diffrn_source.take-off_angle     ?
+_diffrn_source.pdbx_wavelength_list 0.97619
+_diffrn_source.pdbx_wavelength    ?
+_diffrn_source.pdbx_synchrotron_beamline 21-ID-D
+_diffrn_source.pdbx_synchrotron_site APS
+
+_reflns.B_iso_Wilson_estimate     ?
+_reflns.entry_id                  8VJT
+_reflns.data_reduction_details    ?
+_reflns.data_reduction_method     ?
+_reflns.d_resolution_high         1.052
+_reflns.d_resolution_low          21.726
+_reflns.details
+;Someremarks regarding the mmCIF items written, the PDB Exchange Dictionary (PDBx/mmCIF) Version 5.0 supporting the data files in the current PDB archive (dictionary version 5.325, last updated 2020-04-13: http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Index/) and the actual quantities provided by MRFANA (https://github.com/githubgphl/MRFANA) from the autoPROC package (https://www.globalphasing.com/autoproc/). In general, the mmCIF categories here should provide items that are currently used in the PDB archive. If there are alternatives, the one recommended by the PDB developers has been selected.The distinction between *_all and *_obs quantities is not always clear: often only one version is actively used within the PDB archive (or is the one recommended by PDB developers). The intention of distinguishing between classes of reflections before and after some kind of observation criterion was applied, can in principle be useful - but such criteria change in various ways throughout the data processing steps (rejection of overloaded or too partial reflections, outlier/misfit rejections during scaling etc) and there is no retrospect computation of data scaling/merging statistics for the reflections used in the final refinement (where another observation criterion might have been applied). Typical data processing will usually only provide one version of statistics at various stages and these are given in the recommended item here, irrespective of the "_all" and "_obs" connotation, see e.g. the use of _reflns.pdbx_Rmerge_I_obs, _reflns.pdbx_Rrim_I_all and _reflns.pdbx_Rpim_I_all.Please note that all statistics related to "merged intensities" (or "merging") are based on inverse-variance weighting of the individual measurements making up a symmetry-unique reflection. This is standard for several decades now, even if some of the dictionary definitions seem to suggest that a simple "mean" or "average" intensity is being used instead.R-values are always given for all symmetry-equivalent reflections following Friedel's law, i.e. Bijvoet pairs are not treated separately (since we want to describe the overall mean intensity and not the mean I(+) and I(-) here).The Rrim metric is identical to the Rmeas R-value and only differs in name._reflns.pdbx_number_measured_all is the number of measured intensities just before the final merging step (at which point no additional rejection takes place)._reflns.number_obs is the number of symmetry-unique observations, i.e. the result of merging those measurements via inverse-variance weighting._reflns.pdbx_netI_over_sigmaI is based on the merged intensities (_reflns.number_obs) as expected._reflns.pdbx_redundancy is synonymous with "multiplicity".The per-shell item _reflns_shell.number_measured_all corresponds to the overall value _reflns.pdbx_number_measured_all.The per-shell item _reflns_shell.number_unique_all corresponds to the overall value _reflns.number_obs.The per-shell item _reflns_shell.percent_possible_all corresponds to the overall value _reflns.percent_possible_obs.The per-shell item _reflns_shell.meanI_over_sigI_obs corresponds to the overall value given as _reflns.pdbx_netI_over_sigmaI. But be aware of the incorrect definition of the former in the current dictionary!
+;
+_reflns.limit_h_max               ?
+_reflns.limit_h_min               ?
+_reflns.limit_k_max               ?
+_reflns.limit_k_min               ?
+_reflns.limit_l_max               ?
+_reflns.limit_l_min               ?
+_reflns.number_all                ?
+_reflns.number_obs                14743
+_reflns.observed_criterion        ?
+_reflns.observed_criterion_F_max  ?
+_reflns.observed_criterion_F_min  ?
+_reflns.observed_criterion_I_max  ?
+_reflns.observed_criterion_I_min  ?
+_reflns.observed_criterion_sigma_F ?
+_reflns.observed_criterion_sigma_I ?
+_reflns.percent_possible_obs      95.9
+_reflns.R_free_details            ?
+_reflns.Rmerge_F_all              ?
+_reflns.Rmerge_F_obs              ?
+_reflns.Friedel_coverage          ?
+_reflns.number_gt                 ?
+_reflns.threshold_expression      ?
+_reflns.pdbx_redundancy           12.98
+_reflns.pdbx_netI_over_av_sigmaI  ?
+_reflns.pdbx_netI_over_sigmaI     18.35
+_reflns.pdbx_res_netI_over_av_sigmaI_2 ?
+_reflns.pdbx_res_netI_over_sigmaI_2 ?
+_reflns.pdbx_chi_squared          ?
+_reflns.pdbx_scaling_rejects      ?
+_reflns.pdbx_d_res_high_opt       ?
+_reflns.pdbx_d_res_low_opt        ?
+_reflns.pdbx_d_res_opt_method     ?
+_reflns.phase_calculation_details ?
+_reflns.pdbx_Rrim_I_all           0.0803
+_reflns.pdbx_Rpim_I_all           0.0221
+_reflns.pdbx_d_opt                ?
+_reflns.pdbx_number_measured_all  191357
+_reflns.pdbx_diffrn_id            1
+_reflns.pdbx_ordinal              1
+_reflns.pdbx_CC_half              0.995
+_reflns.pdbx_CC_star              ?
+_reflns.pdbx_R_split              ?
+_reflns.pdbx_Rmerge_I_obs         0.0770
+_reflns.pdbx_Rmerge_I_all         ?
+_reflns.pdbx_Rsym_value           ?
+_reflns.pdbx_CC_split_method      ?
+_reflns.pdbx_aniso_diffraction_limit_axis_1_ortho[1] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_1_ortho[2] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_1_ortho[3] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_2_ortho[1] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_2_ortho[2] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_2_ortho[3] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_3_ortho[1] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_3_ortho[2] ?
+_reflns.pdbx_aniso_diffraction_limit_axis_3_ortho[3] ?
+_reflns.pdbx_aniso_diffraction_limit_1 ?
+_reflns.pdbx_aniso_diffraction_limit_2 ?
+_reflns.pdbx_aniso_diffraction_limit_3 ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_1_ortho[1] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_1_ortho[2] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_1_ortho[3] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_2_ortho[1] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_2_ortho[2] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_2_ortho[3] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_3_ortho[1] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_3_ortho[2] ?
+_reflns.pdbx_aniso_B_tensor_eigenvector_3_ortho[3] ?
+_reflns.pdbx_aniso_B_tensor_eigenvalue_1 ?
+_reflns.pdbx_aniso_B_tensor_eigenvalue_2 ?
+_reflns.pdbx_aniso_B_tensor_eigenvalue_3 ?
+_reflns.pdbx_orthogonalization_convention ?
+_reflns.pdbx_percent_possible_ellipsoidal ?
+_reflns.pdbx_percent_possible_spherical ?
+_reflns.pdbx_percent_possible_ellipsoidal_anomalous ?
+_reflns.pdbx_percent_possible_spherical_anomalous ?
+_reflns.pdbx_redundancy_anomalous 7.11
+_reflns.pdbx_CC_half_anomalous    -0.294
+_reflns.pdbx_absDiff_over_sigma_anomalous 0.820
+_reflns.pdbx_percent_possible_anomalous 95.5
+_reflns.pdbx_observed_signal_threshold ?
+_reflns.pdbx_signal_type          ?
+_reflns.pdbx_signal_details       ?
+_reflns.pdbx_signal_software_id   ?
+
+loop_
+_reflns_shell.d_res_high
+_reflns_shell.d_res_low
+_reflns_shell.meanI_over_sigI_all
+_reflns_shell.meanI_over_sigI_obs
+_reflns_shell.number_measured_all
+_reflns_shell.number_measured_obs
+_reflns_shell.number_possible
+_reflns_shell.number_unique_all
+_reflns_shell.number_unique_obs
+_reflns_shell.percent_possible_obs
+_reflns_shell.Rmerge_F_all
+_reflns_shell.Rmerge_F_obs
+_reflns_shell.meanI_over_sigI_gt
+_reflns_shell.meanI_over_uI_all
+_reflns_shell.meanI_over_uI_gt
+_reflns_shell.number_measured_gt
+_reflns_shell.number_unique_gt
+_reflns_shell.percent_possible_gt
+_reflns_shell.Rmerge_F_gt
+_reflns_shell.Rmerge_I_gt
+_reflns_shell.pdbx_redundancy
+_reflns_shell.pdbx_chi_squared
+_reflns_shell.pdbx_netI_over_sigmaI_all
+_reflns_shell.pdbx_netI_over_sigmaI_obs
+_reflns_shell.pdbx_Rrim_I_all
+_reflns_shell.pdbx_Rpim_I_all
+_reflns_shell.pdbx_rejects
+_reflns_shell.pdbx_ordinal
+_reflns_shell.pdbx_diffrn_id
+_reflns_shell.pdbx_CC_half
+_reflns_shell.pdbx_CC_star
+_reflns_shell.pdbx_R_split
+_reflns_shell.percent_possible_all
+_reflns_shell.Rmerge_I_all
+_reflns_shell.Rmerge_I_obs
+_reflns_shell.pdbx_Rsym_value
+_reflns_shell.pdbx_percent_possible_ellipsoidal
+_reflns_shell.pdbx_percent_possible_spherical
+_reflns_shell.pdbx_percent_possible_ellipsoidal_anomalous
+_reflns_shell.pdbx_percent_possible_spherical_anomalous
+_reflns_shell.pdbx_redundancy_anomalous
+_reflns_shell.pdbx_CC_half_anomalous
+_reflns_shell.pdbx_absDiff_over_sigma_anomalous
+_reflns_shell.pdbx_percent_possible_anomalous
+2.855 21.726 ? 46.84 12276 12276 ? 890 890 ? ? ? ? ? ? ? ? ? ? ? 13.79 ? ? ? 0.0665 0.0184 ? 1  ? 0.993 ? ? 100.0 ? 0.0637 ? ? ? ? ? 8.63 -0.448 0.963 100.0
+2.267 2.855  ? 40.09 10339 10339 ? 810 810 ? ? ? ? ? ? ? ? ? ? ? 12.76 ? ? ? 0.0562 0.0157 ? 2  ? 0.999 ? ? 99.4  ? 0.0538 ? ? ? ? ? 7.34 0.223  0.951 99.5
+1.980 2.267  ? 37.55 10850 10850 ? 789 789 ? ? ? ? ? ? ? ? ? ? ? 13.75 ? ? ? 0.0617 0.0167 ? 3  ? 0.998 ? ? 100.0 ? 0.0593 ? ? ? ? ? 7.71 0.033  0.951 100.0
+1.799 1.980  ? 34.25 11110 11110 ? 772 772 ? ? ? ? ? ? ? ? ? ? ? 14.39 ? ? ? 0.0670 0.0177 ? 4  ? 0.998 ? ? 100.0 ? 0.0646 ? ? ? ? ? 8.02 0.212  0.915 100.0
+1.670 1.799  ? 30.66 11346 11346 ? 777 777 ? ? ? ? ? ? ? ? ? ? ? 14.60 ? ? ? 0.0740 0.0196 ? 5  ? 0.999 ? ? 100.0 ? 0.0712 ? ? ? ? ? 8.05 -0.004 0.880 100.0
+1.572 1.670  ? 26.77 11485 11485 ? 776 776 ? ? ? ? ? ? ? ? ? ? ? 14.80 ? ? ? 0.0816 0.0218 ? 6  ? 1.000 ? ? 100.0 ? 0.0785 ? ? ? ? ? 8.09 0.055  0.855 100.0
+1.493 1.572  ? 21.28 11325 11325 ? 764 764 ? ? ? ? ? ? ? ? ? ? ? 14.82 ? ? ? 0.1135 0.0292 ? 7  ? 0.998 ? ? 100.0 ? 0.1096 ? ? ? ? ? 8.09 0.189  0.950 100.0
+1.428 1.493  ? 15.64 9866  9866  ? 758 758 ? ? ? ? ? ? ? ? ? ? ? 13.02 ? ? ? 0.1515 0.0411 ? 8  ? 0.994 ? ? 99.9  ? 0.1456 ? ? ? ? ? 7.10 0.093  0.831 100.0
+1.373 1.428  ? 13.83 10183 10183 ? 763 763 ? ? ? ? ? ? ? ? ? ? ? 13.35 ? ? ? 0.1692 0.0456 ? 9  ? 0.994 ? ? 99.5  ? 0.1628 ? ? ? ? ? 7.22 -0.051 0.813 100.0
+1.326 1.373  ? 11.96 10586 10586 ? 763 763 ? ? ? ? ? ? ? ? ? ? ? 13.87 ? ? ? 0.2002 0.0536 ? 10 ? 0.992 ? ? 100.0 ? 0.1927 ? ? ? ? ? 7.53 0.050  0.789 100.0
+1.284 1.326  ? 11.19 10639 10639 ? 756 756 ? ? ? ? ? ? ? ? ? ? ? 14.07 ? ? ? 0.2192 0.0584 ? 11 ? 0.991 ? ? 100.0 ? 0.2111 ? ? ? ? ? 7.59 0.040  0.797 100.0
+1.248 1.284  ? 10.40 10827 10827 ? 758 758 ? ? ? ? ? ? ? ? ? ? ? 14.28 ? ? ? 0.2428 0.0641 ? 12 ? 0.989 ? ? 100.0 ? 0.2339 ? ? ? ? ? 7.72 0.019  0.783 100.0
+1.215 1.248  ? 9.28  10610 10610 ? 739 739 ? ? ? ? ? ? ? ? ? ? ? 14.36 ? ? ? 0.2677 0.0705 ? 13 ? 0.987 ? ? 100.0 ? 0.2580 ? ? ? ? ? 7.70 0.035  0.768 100.0
+1.185 1.215  ? 8.60  10964 10964 ? 768 768 ? ? ? ? ? ? ? ? ? ? ? 14.28 ? ? ? 0.2855 0.0752 ? 14 ? 0.989 ? ? 100.0 ? 0.2752 ? ? ? ? ? 7.66 0.013  0.749 100.0
+1.158 1.185  ? 7.75  10722 10722 ? 754 754 ? ? ? ? ? ? ? ? ? ? ? 14.22 ? ? ? 0.3200 0.0848 ? 15 ? 0.983 ? ? 100.0 ? 0.3081 ? ? ? ? ? 7.66 0.028  0.791 100.0
+1.134 1.158  ? 6.47  9419  9419  ? 736 736 ? ? ? ? ? ? ? ? ? ? ? 12.80 ? ? ? 0.3615 0.1006 ? 16 ? 0.990 ? ? 99.6  ? 0.3466 ? ? ? ? ? 6.81 0.061  0.718 99.7
+1.111 1.134  ? 4.44  6673  6673  ? 666 666 ? ? ? ? ? ? ? ? ? ? ? 10.02 ? ? ? 0.4633 0.1425 ? 17 ? 0.955 ? ? 89.9  ? 0.4392 ? ? ? ? ? 5.36 -0.099 0.689 90.6
+1.090 1.111  ? 3.38  5380  5380  ? 659 659 ? ? ? ? ? ? ? ? ? ? ? 8.16  ? ? ? 0.5369 0.1834 ? 18 ? 0.934 ? ? 86.5  ? 0.5012 ? ? ? ? ? 4.42 -0.002 0.738 86.6
+1.071 1.090  ? 2.58  4152  4152  ? 586 586 ? ? ? ? ? ? ? ? ? ? ? 7.09  ? ? ? 0.6751 0.2428 ? 19 ? 0.884 ? ? 77.0  ? 0.6262 ? ? ? ? ? 3.87 0.056  0.732 74.6
+1.052 1.071  ? 1.77  2605  2605  ? 459 459 ? ? ? ? ? ? ? ? ? ? ? 5.68  ? ? ? 0.8838 0.3542 ? 20 ? 0.690 ? ? 62.9  ? 0.8026 ? ? ? ? ? 3.14 -0.003 0.685 60.4
+
+_refine.aniso_B[1][1]             ?
+_refine.aniso_B[1][2]             ?
+_refine.aniso_B[1][3]             ?
+_refine.aniso_B[2][2]             ?
+_refine.aniso_B[2][3]             ?
+_refine.aniso_B[3][3]             ?
+_refine.B_iso_max                 ?
+_refine.B_iso_mean                13.57
+_refine.B_iso_min                 ?
+_refine.correlation_coeff_Fo_to_Fc ?
+_refine.correlation_coeff_Fo_to_Fc_free ?
+_refine.details                   ?
+_refine.diff_density_max          ?
+_refine.diff_density_max_esd      ?
+_refine.diff_density_min          ?
+_refine.diff_density_min_esd      ?
+_refine.diff_density_rms          ?
+_refine.diff_density_rms_esd      ?
+_refine.entry_id                  8VJT
+_refine.pdbx_refine_id            'X-RAY DIFFRACTION'
+_refine.ls_abs_structure_details  ?
+_refine.ls_abs_structure_Flack    ?
+_refine.ls_abs_structure_Flack_esd ?
+_refine.ls_abs_structure_Rogers   ?
+_refine.ls_abs_structure_Rogers_esd ?
+_refine.ls_d_res_high             1.052
+_refine.ls_d_res_low              21.726
+_refine.ls_extinction_coef        ?
+_refine.ls_extinction_coef_esd    ?
+_refine.ls_extinction_expression  ?
+_refine.ls_extinction_method      ?
+_refine.ls_goodness_of_fit_all    ?
+_refine.ls_goodness_of_fit_all_esd ?
+_refine.ls_goodness_of_fit_obs    ?
+_refine.ls_goodness_of_fit_obs_esd ?
+_refine.ls_hydrogen_treatment     ?
+_refine.ls_matrix_type            ?
+_refine.ls_number_constraints     ?
+_refine.ls_number_parameters      ?
+_refine.ls_number_reflns_all      ?
+_refine.ls_number_reflns_obs      14726
+_refine.ls_number_reflns_R_free   1471
+_refine.ls_number_reflns_R_work   13255
+_refine.ls_number_restraints      ?
+_refine.ls_percent_reflns_obs     95.75
+_refine.ls_percent_reflns_R_free  9.99
+_refine.ls_R_factor_all           ?
+_refine.ls_R_factor_obs           0.1496
+_refine.ls_R_factor_R_free        0.1606
+_refine.ls_R_factor_R_free_error  ?
+_refine.ls_R_factor_R_free_error_details ?
+_refine.ls_R_factor_R_work        0.1483
+_refine.ls_R_Fsqd_factor_obs      ?
+_refine.ls_R_I_factor_obs         ?
+_refine.ls_redundancy_reflns_all  ?
+_refine.ls_redundancy_reflns_obs  ?
+_refine.ls_restrained_S_all       ?
+_refine.ls_restrained_S_obs       ?
+_refine.ls_shift_over_esd_max     ?
+_refine.ls_shift_over_esd_mean    ?
+_refine.ls_structure_factor_coef  ?
+_refine.ls_weighting_details      ?
+_refine.ls_weighting_scheme       ?
+_refine.ls_wR_factor_all          ?
+_refine.ls_wR_factor_obs          ?
+_refine.ls_wR_factor_R_free       ?
+_refine.ls_wR_factor_R_work       ?
+_refine.occupancy_max             ?
+_refine.occupancy_min             ?
+_refine.solvent_model_details     'FLAT BULK SOLVENT MODEL'
+_refine.solvent_model_param_bsol  ?
+_refine.solvent_model_param_ksol  ?
+_refine.pdbx_R_complete           ?
+_refine.ls_R_factor_gt            ?
+_refine.ls_goodness_of_fit_gt     ?
+_refine.ls_goodness_of_fit_ref    ?
+_refine.ls_shift_over_su_max      ?
+_refine.ls_shift_over_su_max_lt   ?
+_refine.ls_shift_over_su_mean     ?
+_refine.ls_shift_over_su_mean_lt  ?
+_refine.pdbx_ls_sigma_I           ?
+_refine.pdbx_ls_sigma_F           1.35
+_refine.pdbx_ls_sigma_Fsqd        ?
+_refine.pdbx_data_cutoff_high_absF ?
+_refine.pdbx_data_cutoff_high_rms_absF ?
+_refine.pdbx_data_cutoff_low_absF ?
+_refine.pdbx_isotropic_thermal_model ?
+_refine.pdbx_ls_cross_valid_method 'FREE R-VALUE'
+_refine.pdbx_method_to_determine_struct SIRAS
+_refine.pdbx_starting_model       ?
+_refine.pdbx_stereochemistry_target_values 'GeoStd + Monomer Library + CDL v1.2'
+_refine.pdbx_R_Free_selection_details ?
+_refine.pdbx_stereochem_target_val_spec_case ?
+_refine.pdbx_overall_ESU_R        ?
+_refine.pdbx_overall_ESU_R_Free   ?
+_refine.pdbx_solvent_vdw_probe_radii 1.1000
+_refine.pdbx_solvent_ion_probe_radii ?
+_refine.pdbx_solvent_shrinkage_radii 0.9000
+_refine.pdbx_real_space_R         ?
+_refine.pdbx_density_correlation  ?
+_refine.pdbx_pd_number_of_powder_patterns ?
+_refine.pdbx_pd_number_of_points  ?
+_refine.pdbx_pd_meas_number_of_points ?
+_refine.pdbx_pd_proc_ls_prof_R_factor ?
+_refine.pdbx_pd_proc_ls_prof_wR_factor ?
+_refine.pdbx_pd_Marquardt_correlation_coeff ?
+_refine.pdbx_pd_Fsqrd_R_factor    ?
+_refine.pdbx_pd_ls_matrix_band_width ?
+_refine.pdbx_overall_phase_error  14.5541
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI ?
+_refine.pdbx_overall_SU_R_free_Blow_DPI ?
+_refine.pdbx_overall_SU_R_Blow_DPI ?
+_refine.pdbx_TLS_residual_ADP_flag ?
+_refine.pdbx_diffrn_id            1
+_refine.overall_SU_B              ?
+_refine.overall_SU_ML             0.0808
+_refine.overall_SU_R_Cruickshank_DPI ?
+_refine.overall_SU_R_free         ?
+_refine.overall_FOM_free_R_set    ?
+_refine.overall_FOM_work_R_set    ?
+_refine.pdbx_average_fsc_overall  ?
+_refine.pdbx_average_fsc_work     ?
+_refine.pdbx_average_fsc_free     ?
+
+_refine_hist.pdbx_refine_id       'X-RAY DIFFRACTION'
+_refine_hist.cycle_id             LAST
+_refine_hist.details              ?
+_refine_hist.d_res_high           1.052
+_refine_hist.d_res_low            21.726
+_refine_hist.number_atoms_solvent 39
+_refine_hist.number_atoms_total   300
+_refine_hist.number_reflns_all    ?
+_refine_hist.number_reflns_obs    ?
+_refine_hist.number_reflns_R_free ?
+_refine_hist.number_reflns_R_work ?
+_refine_hist.R_factor_all         ?
+_refine_hist.R_factor_obs         ?
+_refine_hist.R_factor_R_free      ?
+_refine_hist.R_factor_R_work      ?
+_refine_hist.pdbx_number_residues_total ?
+_refine_hist.pdbx_B_iso_mean_ligand ?
+_refine_hist.pdbx_B_iso_mean_solvent ?
+_refine_hist.pdbx_number_atoms_protein 0
+_refine_hist.pdbx_number_atoms_nucleic_acid 252
+_refine_hist.pdbx_number_atoms_ligand 9
+_refine_hist.pdbx_number_atoms_lipid ?
+_refine_hist.pdbx_number_atoms_carb ?
+_refine_hist.pdbx_pseudo_atom_details ?
+
+loop_
+_refine_ls_restr.pdbx_refine_id
+_refine_ls_restr.criterion
+_refine_ls_restr.dev_ideal
+_refine_ls_restr.dev_ideal_target
+_refine_ls_restr.number
+_refine_ls_restr.rejects
+_refine_ls_restr.type
+_refine_ls_restr.weight
+_refine_ls_restr.pdbx_restraint_function
+'X-RAY DIFFRACTION' ? 0.0069  ? 560 ? f_bond_d           ? ?
+'X-RAY DIFFRACTION' ? 1.0642  ? 868 ? f_angle_d          ? ?
+'X-RAY DIFFRACTION' ? 0.0495  ? 116 ? f_chiral_restr     ? ?
+'X-RAY DIFFRACTION' ? 0.0194  ? 24  ? f_plane_restr      ? ?
+'X-RAY DIFFRACTION' ? 14.3081 ? 272 ? f_dihedral_angle_d ? ?
+
+loop_
+_refine_ls_shell.pdbx_refine_id
+_refine_ls_shell.d_res_high
+_refine_ls_shell.d_res_low
+_refine_ls_shell.number_reflns_all
+_refine_ls_shell.number_reflns_obs
+_refine_ls_shell.number_reflns_R_free
+_refine_ls_shell.number_reflns_R_work
+_refine_ls_shell.percent_reflns_obs
+_refine_ls_shell.percent_reflns_R_free
+_refine_ls_shell.R_factor_all
+_refine_ls_shell.R_factor_obs
+_refine_ls_shell.R_factor_R_free_error
+_refine_ls_shell.R_factor_R_work
+_refine_ls_shell.redundancy_reflns_all
+_refine_ls_shell.redundancy_reflns_obs
+_refine_ls_shell.wR_factor_all
+_refine_ls_shell.wR_factor_obs
+_refine_ls_shell.wR_factor_R_free
+_refine_ls_shell.wR_factor_R_work
+_refine_ls_shell.pdbx_R_complete
+_refine_ls_shell.pdbx_total_number_of_bins_used
+_refine_ls_shell.pdbx_phase_error
+_refine_ls_shell.pdbx_fsc_work
+_refine_ls_shell.pdbx_fsc_free
+_refine_ls_shell.R_factor_R_free
+'X-RAY DIFFRACTION' 1.052 1.09   . . 92  844  68.98  . . . . 0.2027 . . . . . . . . . . . 0.2318
+'X-RAY DIFFRACTION' 1.09  1.13   . . 117 1060 86.61  . . . . 0.1530 . . . . . . . . . . . 0.1954
+'X-RAY DIFFRACTION' 1.13  1.17   . . 134 1206 97.95  . . . . 0.1151 . . . . . . . . . . . 0.1523
+'X-RAY DIFFRACTION' 1.17  1.22   . . 137 1230 100.00 . . . . 0.1031 . . . . . . . . . . . 0.1448
+'X-RAY DIFFRACTION' 1.22  1.29   . . 137 1234 100.00 . . . . 0.1069 . . . . . . . . . . . 0.1319
+'X-RAY DIFFRACTION' 1.29  1.37   . . 139 1248 100.00 . . . . 0.1167 . . . . . . . . . . . 0.1553
+'X-RAY DIFFRACTION' 1.37  1.47   . . 136 1230 99.56  . . . . 0.1212 . . . . . . . . . . . 0.1427
+'X-RAY DIFFRACTION' 1.47  1.62   . . 140 1258 99.93  . . . . 0.1118 . . . . . . . . . . . 0.1353
+'X-RAY DIFFRACTION' 1.62  1.86   . . 142 1268 99.51  . . . . 0.1168 . . . . . . . . . . . 0.1291
+'X-RAY DIFFRACTION' 1.86  2.34   . . 142 1288 100.00 . . . . 0.1529 . . . . . . . . . . . 0.1708
+'X-RAY DIFFRACTION' 2.34  21.726 . . 155 1389 99.55  . . . . 0.1883 . . . . . . . . . . . 0.1786
+
+_struct.entry_id                  8VJT
+_struct.title                     'Structure of the poly-UG quadruplex (GUGUGU)4'
+_struct.pdbx_model_details        ?
+_struct.pdbx_formula_weight       ?
+_struct.pdbx_formula_weight_method ?
+_struct.pdbx_model_type_details   ?
+_struct.pdbx_CASP_flag            N
+
+_struct_keywords.entry_id         8VJT
+_struct_keywords.text             'RNA quadruplex, RNA'
+_struct_keywords.pdbx_keywords    RNA
+
+loop_
+_struct_asym.id
+_struct_asym.pdbx_blank_PDB_chainid_flag
+_struct_asym.pdbx_modified
+_struct_asym.entity_id
+_struct_asym.details
+A N N 1 ?
+B N N 1 ?
+C N N 2 ?
+D N N 2 ?
+E N N 2 ?
+F N N 2 ?
+G N N 3 ?
+H N N 2 ?
+I N N 2 ?
+J N N 2 ?
+K N N 3 ?
+L N N 4 ?
+M N N 4 ?
+
+_struct_ref.id                    1
+_struct_ref.db_name               PDB
+_struct_ref.db_code               8VJT
+_struct_ref.pdbx_db_accession     8VJT
+_struct_ref.pdbx_db_isoform       ?
+_struct_ref.entity_id             1
+_struct_ref.pdbx_seq_one_letter_code ?
+_struct_ref.pdbx_align_begin      1
+
+loop_
+_struct_ref_seq.align_id
+_struct_ref_seq.ref_id
+_struct_ref_seq.pdbx_PDB_id_code
+_struct_ref_seq.pdbx_strand_id
+_struct_ref_seq.seq_align_beg
+_struct_ref_seq.pdbx_seq_align_beg_ins_code
+_struct_ref_seq.seq_align_end
+_struct_ref_seq.pdbx_seq_align_end_ins_code
+_struct_ref_seq.pdbx_db_accession
+_struct_ref_seq.db_align_beg
+_struct_ref_seq.pdbx_db_align_beg_ins_code
+_struct_ref_seq.db_align_end
+_struct_ref_seq.pdbx_db_align_end_ins_code
+_struct_ref_seq.pdbx_auth_seq_align_beg
+_struct_ref_seq.pdbx_auth_seq_align_end
+1 1 8VJT A 1 ? 6 ? 8VJT 1 ? 6 ? 1 6
+2 1 8VJT B 1 ? 6 ? 8VJT 1 ? 6 ? 1 6
+
+loop_
+_pdbx_struct_assembly.id
+_pdbx_struct_assembly.details
+_pdbx_struct_assembly.method_details
+_pdbx_struct_assembly.oligomeric_details
+_pdbx_struct_assembly.oligomeric_count
+1 author_and_software_defined_assembly PISA tetrameric 4
+2 author_and_software_defined_assembly PISA tetrameric 4
+
+loop_
+_pdbx_struct_assembly_prop.biol_id
+_pdbx_struct_assembly_prop.type
+_pdbx_struct_assembly_prop.value
+_pdbx_struct_assembly_prop.details
+1 'ABSA (A^2)' 2870 ?
+1 MORE         -83  ?
+1 'SSA (A^2)'  3760 ?
+2 'ABSA (A^2)' 2650 ?
+2 MORE         -88  ?
+2 'SSA (A^2)'  3960 ?
+
+loop_
+_pdbx_struct_assembly_gen.assembly_id
+_pdbx_struct_assembly_gen.oper_expression
+_pdbx_struct_assembly_gen.asym_id_list
+1 1,2,3,4 A,C,D,E,F,G,L
+2 1,2,3,4 B,H,I,J,K,M
+
+loop_
+_pdbx_struct_oper_list.id
+_pdbx_struct_oper_list.type
+_pdbx_struct_oper_list.name
+_pdbx_struct_oper_list.symmetry_operation
+_pdbx_struct_oper_list.matrix[1][1]
+_pdbx_struct_oper_list.matrix[1][2]
+_pdbx_struct_oper_list.matrix[1][3]
+_pdbx_struct_oper_list.vector[1]
+_pdbx_struct_oper_list.matrix[2][1]
+_pdbx_struct_oper_list.matrix[2][2]
+_pdbx_struct_oper_list.matrix[2][3]
+_pdbx_struct_oper_list.vector[2]
+_pdbx_struct_oper_list.matrix[3][1]
+_pdbx_struct_oper_list.matrix[3][2]
+_pdbx_struct_oper_list.matrix[3][3]
+_pdbx_struct_oper_list.vector[3]
+1 'identity operation'         1_555 x,y,z          1.0000000000  0.0000000000  0.0000000000 0.0000000000   0.0000000000  1.0000000000  0.0000000000 0.0000000000  0.0000000000 0.0000000000 1.0000000000 0.0000000000
+2 'crystal symmetry operation' 2_565 -x,-y+1,z      -1.0000000000 0.0000000000  0.0000000000 0.0000000000   0.0000000000  -1.0000000000 0.0000000000 32.8210000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000
+3 'crystal symmetry operation' 3_555 -y+1/2,x+1/2,z 0.0000000000  -1.0000000000 0.0000000000 16.4105000000  1.0000000000  0.0000000000  0.0000000000 16.4105000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000
+4 'crystal symmetry operation' 4_455 y-1/2,-x+1/2,z 0.0000000000  1.0000000000  0.0000000000 -16.4105000000 -1.0000000000 0.0000000000  0.0000000000 16.4105000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000
+
+loop_
+_struct_conn.id
+_struct_conn.conn_type_id
+_struct_conn.pdbx_leaving_atom_flag
+_struct_conn.pdbx_PDB_id
+_struct_conn.ptnr1_label_asym_id
+_struct_conn.ptnr1_label_comp_id
+_struct_conn.ptnr1_label_seq_id
+_struct_conn.ptnr1_label_atom_id
+_struct_conn.pdbx_ptnr1_label_alt_id
+_struct_conn.pdbx_ptnr1_PDB_ins_code
+_struct_conn.pdbx_ptnr1_standard_comp_id
+_struct_conn.ptnr1_symmetry
+_struct_conn.ptnr2_label_asym_id
+_struct_conn.ptnr2_label_comp_id
+_struct_conn.ptnr2_label_seq_id
+_struct_conn.ptnr2_label_atom_id
+_struct_conn.pdbx_ptnr2_label_alt_id
+_struct_conn.pdbx_ptnr2_PDB_ins_code
+_struct_conn.ptnr1_auth_asym_id
+_struct_conn.ptnr1_auth_comp_id
+_struct_conn.ptnr1_auth_seq_id
+_struct_conn.ptnr2_auth_asym_id
+_struct_conn.ptnr2_auth_comp_id
+_struct_conn.ptnr2_auth_seq_id
+_struct_conn.ptnr2_symmetry
+_struct_conn.pdbx_ptnr3_label_atom_id
+_struct_conn.pdbx_ptnr3_label_seq_id
+_struct_conn.pdbx_ptnr3_label_comp_id
+_struct_conn.pdbx_ptnr3_label_asym_id
+_struct_conn.pdbx_ptnr3_label_alt_id
+_struct_conn.pdbx_ptnr3_PDB_ins_code
+_struct_conn.details
+_struct_conn.pdbx_dist_value
+_struct_conn.pdbx_value_order
+_struct_conn.pdbx_role
+metalc1  metalc ? ? A G  1 O6    A ? ? 1_555 C K   . K  ? ? A G  1   A K   101 1_555 ? ? ? ? ? ? ?             2.911 ? ?
+metalc2  metalc ? ? A G  1 O6    B ? ? 1_555 C K   . K  ? ? A G  1   A K   101 1_555 ? ? ? ? ? ? ?             2.680 ? ?
+metalc3  metalc ? ? A G  1 O6    A ? ? 1_555 C K   . K  ? ? A G  1   A K   101 2_565 ? ? ? ? ? ? ?             2.911 ? ?
+metalc4  metalc ? ? A G  1 O6    B ? ? 1_555 C K   . K  ? ? A G  1   A K   101 2_565 ? ? ? ? ? ? ?             2.680 ? ?
+metalc5  metalc ? ? A G  1 O6    A ? ? 1_555 D K   . K  ? ? A G  1   A K   102 1_555 ? ? ? ? ? ? ?             2.808 ? ?
+metalc6  metalc ? ? A G  1 O6    B ? ? 1_555 D K   . K  ? ? A G  1   A K   102 1_555 ? ? ? ? ? ? ?             2.906 ? ?
+metalc7  metalc ? ? A G  1 O6    A ? ? 1_555 D K   . K  ? ? A G  1   A K   102 2_565 ? ? ? ? ? ? ?             2.808 ? ?
+metalc8  metalc ? ? A G  1 O6    B ? ? 1_555 D K   . K  ? ? A G  1   A K   102 2_565 ? ? ? ? ? ? ?             2.906 ? ?
+metalc9  metalc ? ? A G  3 O6    A ? ? 1_555 D K   . K  ? ? A G  3   A K   102 1_555 ? ? ? ? ? ? ?             2.823 ? ?
+metalc10 metalc ? ? A G  3 O6    B ? ? 1_555 D K   . K  ? ? A G  3   A K   102 1_555 ? ? ? ? ? ? ?             2.705 ? ?
+metalc11 metalc ? ? A G  3 O6    A ? ? 1_555 D K   . K  ? ? A G  3   A K   102 2_565 ? ? ? ? ? ? ?             2.823 ? ?
+metalc12 metalc ? ? A G  3 O6    B ? ? 1_555 D K   . K  ? ? A G  3   A K   102 2_565 ? ? ? ? ? ? ?             2.705 ? ?
+metalc13 metalc ? ? A U  4 O4    A ? ? 1_555 E K   . K  ? ? A U  4   A K   103 1_555 ? ? ? ? ? ? ?             2.702 ? ?
+metalc14 metalc ? ? A U  4 O4    B ? ? 1_555 E K   . K  ? ? A U  4   A K   103 1_555 ? ? ? ? ? ? ?             2.715 ? ?
+metalc15 metalc ? ? A U  4 O4    A ? ? 1_555 E K   . K  ? ? A U  4   A K   103 2_565 ? ? ? ? ? ? ?             2.702 ? ?
+metalc16 metalc ? ? A U  4 O4    B ? ? 1_555 E K   . K  ? ? A U  4   A K   103 2_565 ? ? ? ? ? ? ?             2.715 ? ?
+metalc17 metalc ? ? A G  5 O6    A ? ? 1_555 E K   . K  ? ? A G  5   A K   103 1_555 ? ? ? ? ? ? ?             2.800 ? ?
+metalc18 metalc ? ? A G  5 O6    B ? ? 1_555 E K   . K  ? ? A G  5   A K   103 1_555 ? ? ? ? ? ? ?             2.742 ? ?
+metalc19 metalc ? ? A G  5 O6    A ? ? 1_555 E K   . K  ? ? A G  5   A K   103 2_565 ? ? ? ? ? ? ?             2.800 ? ?
+metalc20 metalc ? ? A G  5 O6    B ? ? 1_555 E K   . K  ? ? A G  5   A K   103 2_565 ? ? ? ? ? ? ?             2.742 ? ?
+metalc21 metalc ? ? A G  5 O6    A ? ? 1_555 F K   . K  ? ? A G  5   A K   104 1_555 ? ? ? ? ? ? ?             3.021 ? ?
+metalc22 metalc ? ? A G  5 O6    B ? ? 1_555 F K   . K  ? ? A G  5   A K   104 1_555 ? ? ? ? ? ? ?             2.853 ? ?
+metalc23 metalc ? ? A G  5 O6    A ? ? 1_555 F K   . K  ? ? A G  5   A K   104 2_565 ? ? ? ? ? ? ?             3.021 ? ?
+metalc24 metalc ? ? A G  5 O6    B ? ? 1_555 F K   . K  ? ? A G  5   A K   104 2_565 ? ? ? ? ? ? ?             2.853 ? ?
+metalc25 metalc ? ? A U  6 O4    A ? ? 1_555 F K   . K  ? ? A U  6   A K   104 1_555 ? ? ? ? ? ? ?             2.791 ? ?
+metalc26 metalc ? ? A U  6 O4    B ? ? 1_555 F K   . K  ? ? A U  6   A K   104 1_555 ? ? ? ? ? ? ?             2.688 ? ?
+metalc27 metalc ? ? A U  6 O4    A ? ? 1_555 F K   . K  ? ? A U  6   A K   104 2_565 ? ? ? ? ? ? ?             2.791 ? ?
+metalc28 metalc ? ? A U  6 O4    B ? ? 1_555 F K   . K  ? ? A U  6   A K   104 2_565 ? ? ? ? ? ? ?             2.688 ? ?
+metalc29 metalc ? ? A U  6 "O3'" A ? ? 1_555 G NA  . NA ? ? A U  6   A NA  105 1_555 ? ? ? ? ? ? ?             2.291 ? ?
+metalc30 metalc ? ? A U  6 "O3'" B ? ? 1_555 G NA  . NA ? ? A U  6   A NA  105 1_555 ? ? ? ? ? ? ?             2.562 ? ?
+metalc31 metalc ? ? A U  6 "O2'" A ? ? 1_555 G NA  . NA ? ? A U  6   A NA  105 1_555 ? ? ? ? ? ? ?             2.507 ? ?
+metalc32 metalc ? ? A U  6 "O2'" B ? ? 1_555 G NA  . NA ? ? A U  6   A NA  105 1_555 ? ? ? ? ? ? ?             2.593 ? ?
+metalc33 metalc ? ? C K  . K     ? ? ? 1_555 B G   1 O6 A ? A K  101 B G   1   1_555 ? ? ? ? ? ? ?             2.790 ? ?
+metalc34 metalc ? ? C K  . K     ? ? ? 1_555 B G   1 O6 B ? A K  101 B G   1   1_555 ? ? ? ? ? ? ?             2.809 ? ?
+metalc35 metalc ? ? C K  . K     ? ? ? 2_565 B G   1 O6 A ? A K  101 B G   1   1_555 ? ? ? ? ? ? ?             2.790 ? ?
+metalc36 metalc ? ? C K  . K     ? ? ? 2_565 B G   1 O6 B ? A K  101 B G   1   1_555 ? ? ? ? ? ? ?             2.809 ? ?
+metalc37 metalc ? ? D K  . K     ? ? ? 1_555 L HOH . O  ? ? A K  102 A HOH 210 1_555 ? ? ? ? ? ? ?             3.279 ? ?
+metalc38 metalc ? ? D K  . K     ? ? ? 1_555 L HOH . O  ? ? A K  102 A HOH 210 2_565 ? ? ? ? ? ? ?             3.279 ? ?
+metalc39 metalc ? ? E K  . K     ? ? ? 1_555 L HOH . O  ? ? A K  103 A HOH 210 1_555 ? ? ? ? ? ? ?             3.045 ? ?
+metalc40 metalc ? ? E K  . K     ? ? ? 1_555 L HOH . O  ? ? A K  103 A HOH 210 2_565 ? ? ? ? ? ? ?             3.045 ? ?
+metalc41 metalc ? ? G NA . NA    ? ? ? 1_555 L HOH . O  ? ? A NA 105 A HOH 204 1_555 ? ? ? ? ? ? ?             2.472 ? ?
+metalc42 metalc ? ? G NA . NA    ? ? ? 1_555 L HOH . O  ? ? A NA 105 A HOH 206 1_555 ? ? ? ? ? ? ?             2.359 ? ?
+metalc43 metalc ? ? G NA . NA    ? ? ? 1_555 L HOH . O  ? ? A NA 105 A HOH 211 3_555 ? ? ? ? ? ? ?             2.490 ? ?
+metalc44 metalc ? ? G NA . NA    ? ? ? 1_555 L HOH . O  ? ? A NA 105 A HOH 220 1_555 ? ? ? ? ? ? ?             2.457 ? ?
+metalc45 metalc ? ? G NA . NA    ? ? ? 1_555 L HOH . O  ? ? A NA 105 A HOH 220 7_555 ? ? ? ? ? ? ?             2.457 ? ?
+metalc46 metalc ? ? B G  1 O6    A ? ? 1_555 J K   . K  ? ? B G  1   B K   103 1_555 ? ? ? ? ? ? ?             2.953 ? ?
+metalc47 metalc ? ? B G  1 O6    B ? ? 1_555 J K   . K  ? ? B G  1   B K   103 1_555 ? ? ? ? ? ? ?             2.880 ? ?
+metalc48 metalc ? ? B G  1 O6    A ? ? 1_555 J K   . K  ? ? B G  1   B K   103 2_565 ? ? ? ? ? ? ?             2.953 ? ?
+metalc49 metalc ? ? B G  1 O6    B ? ? 1_555 J K   . K  ? ? B G  1   B K   103 2_565 ? ? ? ? ? ? ?             2.880 ? ?
+metalc50 metalc ? ? B G  3 O6    A ? ? 1_555 J K   . K  ? ? B G  3   B K   103 1_555 ? ? ? ? ? ? ?             2.650 ? ?
+metalc51 metalc ? ? B G  3 O6    B ? ? 1_555 J K   . K  ? ? B G  3   B K   103 1_555 ? ? ? ? ? ? ?             2.598 ? ?
+metalc52 metalc ? ? B G  3 O6    A ? ? 1_555 J K   . K  ? ? B G  3   B K   103 2_565 ? ? ? ? ? ? ?             2.650 ? ?
+metalc53 metalc ? ? B G  3 O6    B ? ? 1_555 J K   . K  ? ? B G  3   B K   103 2_565 ? ? ? ? ? ? ?             2.598 ? ?
+metalc54 metalc ? ? B U  4 O4    A ? ? 1_555 I K   . K  ? ? B U  4   B K   102 1_555 ? ? ? ? ? ? ?             2.674 ? ?
+metalc55 metalc ? ? B U  4 O4    B ? ? 1_555 I K   . K  ? ? B U  4   B K   102 1_555 ? ? ? ? ? ? ?             2.719 ? ?
+metalc56 metalc ? ? B U  4 O4    A ? ? 1_555 I K   . K  ? ? B U  4   B K   102 2_565 ? ? ? ? ? ? ?             2.674 ? ?
+metalc57 metalc ? ? B U  4 O4    B ? ? 1_555 I K   . K  ? ? B U  4   B K   102 2_565 ? ? ? ? ? ? ?             2.719 ? ?
+metalc58 metalc ? ? B G  5 O6    A ? ? 1_555 H K   . K  ? ? B G  5   B K   101 1_555 ? ? ? ? ? ? ?             2.770 ? ?
+metalc59 metalc ? ? B G  5 O6    B ? ? 1_555 H K   . K  ? ? B G  5   B K   101 1_555 ? ? ? ? ? ? ?             2.867 ? ?
+metalc60 metalc ? ? B G  5 O6    A ? ? 1_555 H K   . K  ? ? B G  5   B K   101 2_565 ? ? ? ? ? ? ?             2.770 ? ?
+metalc61 metalc ? ? B G  5 O6    B ? ? 1_555 H K   . K  ? ? B G  5   B K   101 2_565 ? ? ? ? ? ? ?             2.867 ? ?
+metalc62 metalc ? ? B G  5 O6    A ? ? 1_555 I K   . K  ? ? B G  5   B K   102 1_555 ? ? ? ? ? ? ?             2.785 ? ?
+metalc63 metalc ? ? B G  5 O6    B ? ? 1_555 I K   . K  ? ? B G  5   B K   102 1_555 ? ? ? ? ? ? ?             2.906 ? ?
+metalc64 metalc ? ? B G  5 O6    A ? ? 1_555 I K   . K  ? ? B G  5   B K   102 2_565 ? ? ? ? ? ? ?             2.785 ? ?
+metalc65 metalc ? ? B G  5 O6    B ? ? 1_555 I K   . K  ? ? B G  5   B K   102 2_565 ? ? ? ? ? ? ?             2.906 ? ?
+metalc66 metalc ? ? B U  6 O4    A ? ? 1_555 H K   . K  ? ? B U  6   B K   101 1_555 ? ? ? ? ? ? ?             2.710 ? ?
+metalc67 metalc ? ? B U  6 O4    B ? ? 1_555 H K   . K  ? ? B U  6   B K   101 1_555 ? ? ? ? ? ? ?             2.786 ? ?
+metalc68 metalc ? ? B U  6 O4    A ? ? 1_555 H K   . K  ? ? B U  6   B K   101 2_565 ? ? ? ? ? ? ?             2.710 ? ?
+metalc69 metalc ? ? B U  6 O4    B ? ? 1_555 H K   . K  ? ? B U  6   B K   101 2_565 ? ? ? ? ? ? ?             2.786 ? ?
+metalc70 metalc ? ? B U  6 "O3'" B ? ? 1_555 K NA  . NA ? ? B U  6   B NA  104 1_555 ? ? ? ? ? ? ?             2.534 ? ?
+metalc71 metalc ? ? B U  6 "O2'" A ? ? 1_555 K NA  . NA ? ? B U  6   B NA  104 1_555 ? ? ? ? ? ? ?             2.475 ? ?
+metalc72 metalc ? ? B U  6 "O2'" B ? ? 1_555 K NA  . NA ? ? B U  6   B NA  104 1_555 ? ? ? ? ? ? ?             2.411 ? ?
+metalc73 metalc ? ? K NA . NA    ? ? ? 1_555 M HOH . O  B ? B NA 104 B HOH 203 1_555 ? ? ? ? ? ? ?             2.412 ? ?
+metalc74 metalc ? ? K NA . NA    ? ? ? 1_555 M HOH . O  A ? B NA 104 B HOH 203 1_555 ? ? ? ? ? ? ?             2.381 ? ?
+metalc75 metalc ? ? K NA . NA    ? ? ? 1_555 M HOH . O  ? ? B NA 104 B HOH 206 1_555 ? ? ? ? ? ? ?             2.086 ? ?
+metalc76 metalc ? ? K NA . NA    ? ? ? 1_555 M HOH . O  ? ? B NA 104 B HOH 210 1_555 ? ? ? ? ? ? ?             2.156 ? ?
+hydrog1  hydrog ? ? A G  1 N1    A ? ? 1_555 A G   1 O6 A ? A G  1   A G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog2  hydrog ? ? A G  1 N1    B ? ? 1_555 A G   1 O6 B ? A G  1   A G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog3  hydrog ? ? A G  1 N2    A ? ? 1_555 A G   1 N7 A ? A G  1   A G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog4  hydrog ? ? A G  1 N2    B ? ? 1_555 A G   1 N7 B ? A G  1   A G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog5  hydrog ? ? A G  1 N7    A ? ? 1_555 A G   1 N2 A ? A G  1   A G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog6  hydrog ? ? A G  1 N7    B ? ? 1_555 A G   1 N2 B ? A G  1   A G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog7  hydrog ? ? A G  1 O6    A ? ? 1_555 A G   1 N1 A ? A G  1   A G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog8  hydrog ? ? A G  1 O6    B ? ? 1_555 A G   1 N1 B ? A G  1   A G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog9  hydrog ? ? A G  3 N1    A ? ? 1_555 A G   3 O6 A ? A G  3   A G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog10 hydrog ? ? A G  3 N1    B ? ? 1_555 A G   3 O6 B ? A G  3   A G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog11 hydrog ? ? A G  3 N2    A ? ? 1_555 A G   3 N7 A ? A G  3   A G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog12 hydrog ? ? A G  3 N2    B ? ? 1_555 A G   3 N7 B ? A G  3   A G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog13 hydrog ? ? A G  3 N7    A ? ? 1_555 A G   3 N2 A ? A G  3   A G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog14 hydrog ? ? A G  3 N7    B ? ? 1_555 A G   3 N2 B ? A G  3   A G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog15 hydrog ? ? A G  3 O6    A ? ? 1_555 A G   3 N1 A ? A G  3   A G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog16 hydrog ? ? A G  3 O6    B ? ? 1_555 A G   3 N1 B ? A G  3   A G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog17 hydrog ? ? A U  4 N3    A ? ? 1_555 A U   4 O4 A ? A U  4   A U   4   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog18 hydrog ? ? A U  4 N3    B ? ? 1_555 A U   4 O4 B ? A U  4   A U   4   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog19 hydrog ? ? A U  4 O4    A ? ? 1_555 A U   4 N3 A ? A U  4   A U   4   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog20 hydrog ? ? A U  4 O4    B ? ? 1_555 A U   4 N3 B ? A U  4   A U   4   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog21 hydrog ? ? A U  4 O4    A ? ? 1_555 A G   5 N1 A ? A U  4   A G   5   3_555 ? ? ? ? ? ? 'U-G MISPAIR' ?     ? ?
+hydrog22 hydrog ? ? A U  4 O4    B ? ? 1_555 A G   5 N1 B ? A U  4   A G   5   3_555 ? ? ? ? ? ? 'U-G MISPAIR' ?     ? ?
+hydrog23 hydrog ? ? A G  5 N1    A ? ? 1_555 A G   5 O6 A ? A G  5   A G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog24 hydrog ? ? A G  5 N1    B ? ? 1_555 A G   5 O6 B ? A G  5   A G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog25 hydrog ? ? A G  5 N2    A ? ? 1_555 A G   5 N7 A ? A G  5   A G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog26 hydrog ? ? A G  5 N2    B ? ? 1_555 A G   5 N7 B ? A G  5   A G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog27 hydrog ? ? A G  5 N7    A ? ? 1_555 A G   5 N2 A ? A G  5   A G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog28 hydrog ? ? A G  5 N7    B ? ? 1_555 A G   5 N2 B ? A G  5   A G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog29 hydrog ? ? A G  5 O6    A ? ? 1_555 A G   5 N1 A ? A G  5   A G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog30 hydrog ? ? A G  5 O6    B ? ? 1_555 A G   5 N1 B ? A G  5   A G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog31 hydrog ? ? A U  6 N3    A ? ? 1_555 A U   6 O4 A ? A U  6   A U   6   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog32 hydrog ? ? A U  6 N3    B ? ? 1_555 A U   6 O4 B ? A U  6   A U   6   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog33 hydrog ? ? A U  6 O4    A ? ? 1_555 A U   6 N3 A ? A U  6   A U   6   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog34 hydrog ? ? A U  6 O4    B ? ? 1_555 A U   6 N3 B ? A U  6   A U   6   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog35 hydrog ? ? B G  1 N1    A ? ? 1_555 B G   1 O6 A ? B G  1   B G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog36 hydrog ? ? B G  1 N1    B ? ? 1_555 B G   1 O6 B ? B G  1   B G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog37 hydrog ? ? B G  1 N2    A ? ? 1_555 B G   1 N7 A ? B G  1   B G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog38 hydrog ? ? B G  1 N2    B ? ? 1_555 B G   1 N7 B ? B G  1   B G   1   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog39 hydrog ? ? B G  1 N7    A ? ? 1_555 B G   1 N2 A ? B G  1   B G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog40 hydrog ? ? B G  1 N7    B ? ? 1_555 B G   1 N2 B ? B G  1   B G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog41 hydrog ? ? B G  1 O6    A ? ? 1_555 B G   1 N1 A ? B G  1   B G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog42 hydrog ? ? B G  1 O6    B ? ? 1_555 B G   1 N1 B ? B G  1   B G   1   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog43 hydrog ? ? B G  3 N1    A ? ? 1_555 B G   3 O6 A ? B G  3   B G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog44 hydrog ? ? B G  3 N1    B ? ? 1_555 B G   3 O6 B ? B G  3   B G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog45 hydrog ? ? B G  3 N2    A ? ? 1_555 B G   3 N7 A ? B G  3   B G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog46 hydrog ? ? B G  3 N2    B ? ? 1_555 B G   3 N7 B ? B G  3   B G   3   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog47 hydrog ? ? B G  3 N7    A ? ? 1_555 B G   3 N2 A ? B G  3   B G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog48 hydrog ? ? B G  3 N7    B ? ? 1_555 B G   3 N2 B ? B G  3   B G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog49 hydrog ? ? B G  3 O6    A ? ? 1_555 B G   3 N1 A ? B G  3   B G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog50 hydrog ? ? B G  3 O6    B ? ? 1_555 B G   3 N1 B ? B G  3   B G   3   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog51 hydrog ? ? B U  4 N3    A ? ? 1_555 B U   4 O4 A ? B U  4   B U   4   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog52 hydrog ? ? B U  4 N3    B ? ? 1_555 B U   4 O4 B ? B U  4   B U   4   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog53 hydrog ? ? B U  4 O4    A ? ? 1_555 B U   4 N3 A ? B U  4   B U   4   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog54 hydrog ? ? B U  4 O4    B ? ? 1_555 B U   4 N3 B ? B U  4   B U   4   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog55 hydrog ? ? B G  5 N1    A ? ? 1_555 B G   5 O6 A ? B G  5   B G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog56 hydrog ? ? B G  5 N1    B ? ? 1_555 B G   5 O6 B ? B G  5   B G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog57 hydrog ? ? B G  5 N2    A ? ? 1_555 B G   5 N7 A ? B G  5   B G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog58 hydrog ? ? B G  5 N2    B ? ? 1_555 B G   5 N7 B ? B G  5   B G   5   3_555 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog59 hydrog ? ? B G  5 N7    A ? ? 1_555 B G   5 N2 A ? B G  5   B G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog60 hydrog ? ? B G  5 N7    B ? ? 1_555 B G   5 N2 B ? B G  5   B G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog61 hydrog ? ? B G  5 O6    A ? ? 1_555 B G   5 N1 A ? B G  5   B G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog62 hydrog ? ? B G  5 O6    B ? ? 1_555 B G   5 N1 B ? B G  5   B G   5   4_455 ? ? ? ? ? ? TYPE_6_PAIR   ?     ? ?
+hydrog63 hydrog ? ? B U  6 N3    A ? ? 1_555 B U   6 O4 A ? B U  6   B U   6   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog64 hydrog ? ? B U  6 N3    B ? ? 1_555 B U   6 O4 B ? B U  6   B U   6   4_455 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog65 hydrog ? ? B U  6 O4    A ? ? 1_555 B U   6 N3 A ? B U  6   B U   6   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+hydrog66 hydrog ? ? B U  6 O4    B ? ? 1_555 B U   6 N3 B ? B U  6   B U   6   3_555 ? ? ? ? ? ? 'U-U MISPAIR' ?     ? ?
+
+loop_
+_struct_conn_type.id
+_struct_conn_type.criteria
+_struct_conn_type.reference
+metalc ? ?
+hydrog ? ?
+
+loop_
+_pdbx_struct_conn_angle.id
+_pdbx_struct_conn_angle.ptnr1_label_atom_id
+_pdbx_struct_conn_angle.ptnr1_label_alt_id
+_pdbx_struct_conn_angle.ptnr1_label_asym_id
+_pdbx_struct_conn_angle.ptnr1_label_comp_id
+_pdbx_struct_conn_angle.ptnr1_label_seq_id
+_pdbx_struct_conn_angle.ptnr1_auth_atom_id
+_pdbx_struct_conn_angle.ptnr1_auth_asym_id
+_pdbx_struct_conn_angle.ptnr1_auth_comp_id
+_pdbx_struct_conn_angle.ptnr1_auth_seq_id
+_pdbx_struct_conn_angle.ptnr1_PDB_ins_code
+_pdbx_struct_conn_angle.ptnr1_symmetry
+_pdbx_struct_conn_angle.ptnr2_label_atom_id
+_pdbx_struct_conn_angle.ptnr2_label_alt_id
+_pdbx_struct_conn_angle.ptnr2_label_asym_id
+_pdbx_struct_conn_angle.ptnr2_label_comp_id
+_pdbx_struct_conn_angle.ptnr2_label_seq_id
+_pdbx_struct_conn_angle.ptnr2_auth_atom_id
+_pdbx_struct_conn_angle.ptnr2_auth_asym_id
+_pdbx_struct_conn_angle.ptnr2_auth_comp_id
+_pdbx_struct_conn_angle.ptnr2_auth_seq_id
+_pdbx_struct_conn_angle.ptnr2_PDB_ins_code
+_pdbx_struct_conn_angle.ptnr2_symmetry
+_pdbx_struct_conn_angle.ptnr3_label_atom_id
+_pdbx_struct_conn_angle.ptnr3_label_alt_id
+_pdbx_struct_conn_angle.ptnr3_label_asym_id
+_pdbx_struct_conn_angle.ptnr3_label_comp_id
+_pdbx_struct_conn_angle.ptnr3_label_seq_id
+_pdbx_struct_conn_angle.ptnr3_auth_atom_id
+_pdbx_struct_conn_angle.ptnr3_auth_asym_id
+_pdbx_struct_conn_angle.ptnr3_auth_comp_id
+_pdbx_struct_conn_angle.ptnr3_auth_seq_id
+_pdbx_struct_conn_angle.ptnr3_PDB_ins_code
+_pdbx_struct_conn_angle.ptnr3_symmetry
+_pdbx_struct_conn_angle.value
+_pdbx_struct_conn_angle.value_esd
+1   O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 3.8   ?
+2   O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A A G   1 ? A G   1   ? 1_555 0.0   ?
+3   O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A A G   1 ? A G   1   ? 1_555 3.8   ?
+4   O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 3.8   ?
+5   O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 0.0   ?
+6   O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 3.8   ?
+7   O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.2 ?
+8   O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.6 ?
+9   O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.2 ?
+10  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.6 ?
+11  O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 107.0 ?
+12  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 106.9 ?
+13  O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 107.0 ?
+14  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 106.9 ?
+15  O6    A B G   1 ? B G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 7.7   ?
+16  O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.2 ?
+17  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.6 ?
+18  O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.2 ?
+19  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 112.6 ?
+20  O6    A B G   1 ? B G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 0.0   ?
+21  O6    B B G   1 ? B G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 7.7   ?
+22  O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 107.0 ?
+23  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 106.9 ?
+24  O6    A A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 107.0 ?
+25  O6    B A G   1 ? A G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 106.9 ?
+26  O6    A B G   1 ? B G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 7.7   ?
+27  O6    B B G   1 ? B G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 0.0   ?
+28  O6    A B G   1 ? B G   1   ? 1_555 K  ? C K  . ? A K  101 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 7.7   ?
+29  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 5.6   ?
+30  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   1 ? A G   1   ? 1_555 0.0   ?
+31  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   1 ? A G   1   ? 1_555 5.6   ?
+32  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 5.6   ?
+33  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 0.0   ?
+34  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   1 ? A G   1   ? 1_555 5.6   ?
+35  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 85.1  ?
+36  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 90.4  ?
+37  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 85.1  ?
+38  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 90.4  ?
+39  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 89.7  ?
+40  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 95.1  ?
+41  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 89.7  ?
+42  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 95.1  ?
+43  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 4.7   ?
+44  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 85.1  ?
+45  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 90.4  ?
+46  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 85.1  ?
+47  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 90.4  ?
+48  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 0.0   ?
+49  O6    B A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    A A G   3 ? A G   3   ? 1_555 4.7   ?
+50  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 89.7  ?
+51  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 95.1  ?
+52  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 89.7  ?
+53  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 95.1  ?
+54  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 4.7   ?
+55  O6    B A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 0.0   ?
+56  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O6    B A G   3 ? A G   3   ? 1_555 4.7   ?
+57  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 126.6 ?
+58  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 131.8 ?
+59  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 126.6 ?
+60  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 131.8 ?
+61  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 55.9  ?
+62  O6    B A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 51.6  ?
+63  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 55.9  ?
+64  O6    B A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 51.6  ?
+65  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 126.6 ?
+66  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 131.8 ?
+67  O6    A A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 126.6 ?
+68  O6    B A G   1 ? A G   1   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 131.8 ?
+69  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 55.9  ?
+70  O6    B A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 51.6  ?
+71  O6    A A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 55.9  ?
+72  O6    B A G   3 ? A G   3   ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 51.6  ?
+73  O     ? L HOH . ? A HOH 210 ? 1_555 K  ? D K  . ? A K  102 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 0.0   ?
+74  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O4    B A U   4 ? A U   4   ? 1_555 6.3   ?
+75  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O4    A A U   4 ? A U   4   ? 1_555 0.0   ?
+76  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O4    A A U   4 ? A U   4   ? 1_555 6.3   ?
+77  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O4    B A U   4 ? A U   4   ? 1_555 6.3   ?
+78  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O4    B A U   4 ? A U   4   ? 1_555 0.0   ?
+79  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O4    B A U   4 ? A U   4   ? 1_555 6.3   ?
+80  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 72.6  ?
+81  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 66.3  ?
+82  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 72.6  ?
+83  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 66.3  ?
+84  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 78.2  ?
+85  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 71.9  ?
+86  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 78.2  ?
+87  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 71.9  ?
+88  O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 5.9   ?
+89  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 72.6  ?
+90  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 66.3  ?
+91  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 72.6  ?
+92  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 66.3  ?
+93  O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 0.0   ?
+94  O6    B A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 5.9   ?
+95  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 78.2  ?
+96  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 71.9  ?
+97  O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 78.2  ?
+98  O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 71.9  ?
+99  O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 5.9   ?
+100 O6    B A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 0.0   ?
+101 O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 5.9   ?
+102 O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 61.4  ?
+103 O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 66.6  ?
+104 O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 61.4  ?
+105 O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 66.6  ?
+106 O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 123.0 ?
+107 O6    B A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 126.2 ?
+108 O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 123.0 ?
+109 O6    B A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 1_555 126.2 ?
+110 O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 61.4  ?
+111 O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 66.6  ?
+112 O4    A A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 61.4  ?
+113 O4    B A U   4 ? A U   4   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 66.6  ?
+114 O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 123.0 ?
+115 O6    B A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 126.2 ?
+116 O6    A A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 123.0 ?
+117 O6    B A G   5 ? A G   5   ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 126.2 ?
+118 O     ? L HOH . ? A HOH 210 ? 1_555 K  ? E K  . ? A K  103 ? 1_555 O     ? L HOH . ? A HOH 210 ? 2_565 0.0   ?
+119 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 4.7   ?
+120 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 0.0   ?
+121 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O6    A A G   5 ? A G   5   ? 1_555 4.7   ?
+122 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 4.7   ?
+123 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 0.0   ?
+124 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O6    B A G   5 ? A G   5   ? 1_555 4.7   ?
+125 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.7  ?
+126 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.5  ?
+127 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.7  ?
+128 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.5  ?
+129 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.9  ?
+130 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.4  ?
+131 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.9  ?
+132 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.4  ?
+133 O4    A A U   6 ? A U   6   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 5.7   ?
+134 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.7  ?
+135 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.5  ?
+136 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.7  ?
+137 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 68.5  ?
+138 O4    A A U   6 ? A U   6   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 0.0   ?
+139 O4    B A U   6 ? A U   6   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    A A U   6 ? A U   6   ? 1_555 5.7   ?
+140 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.9  ?
+141 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.4  ?
+142 O6    A A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.9  ?
+143 O6    B A G   5 ? A G   5   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 72.4  ?
+144 O4    A A U   6 ? A U   6   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 5.7   ?
+145 O4    B A U   6 ? A U   6   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 0.0   ?
+146 O4    A A U   6 ? A U   6   ? 1_555 K  ? F K  . ? A K  104 ? 1_555 O4    B A U   6 ? A U   6   ? 1_555 5.7   ?
+147 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 "O3'" B A U   6 ? A U   6   ? 1_555 6.7   ?
+148 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 "O2'" A A U   6 ? A U   6   ? 1_555 68.7  ?
+149 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 "O2'" A A U   6 ? A U   6   ? 1_555 65.3  ?
+150 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 "O2'" B A U   6 ? A U   6   ? 1_555 68.0  ?
+151 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 "O2'" B A U   6 ? A U   6   ? 1_555 63.9  ?
+152 "O2'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 "O2'" B A U   6 ? A U   6   ? 1_555 6.4   ?
+153 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 204 ? 1_555 92.8  ?
+154 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 204 ? 1_555 97.7  ?
+155 "O2'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 204 ? 1_555 81.7  ?
+156 "O2'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 204 ? 1_555 88.1  ?
+157 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 206 ? 1_555 156.3 ?
+158 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 206 ? 1_555 150.9 ?
+159 "O2'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 206 ? 1_555 88.7  ?
+160 "O2'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 206 ? 1_555 88.8  ?
+161 O     ? L HOH . ? A HOH 204 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 206 ? 1_555 90.7  ?
+162 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 211 ? 3_555 94.7  ?
+163 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 211 ? 3_555 89.0  ?
+164 "O2'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 211 ? 3_555 92.5  ?
+165 "O2'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 211 ? 3_555 86.2  ?
+166 O     ? L HOH . ? A HOH 204 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 211 ? 3_555 168.2 ?
+167 O     ? L HOH . ? A HOH 206 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 211 ? 3_555 78.9  ?
+168 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 90.0  ?
+169 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 94.7  ?
+170 "O2'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 155.6 ?
+171 "O2'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 157.4 ?
+172 O     ? L HOH . ? A HOH 204 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 87.8  ?
+173 O     ? L HOH . ? A HOH 206 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 113.5 ?
+174 O     ? L HOH . ? A HOH 211 ? 3_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 1_555 101.3 ?
+175 "O3'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 90.0  ?
+176 "O3'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 94.7  ?
+177 "O2'" A A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 155.6 ?
+178 "O2'" B A U   6 ? A U   6   ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 157.4 ?
+179 O     ? L HOH . ? A HOH 204 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 87.8  ?
+180 O     ? L HOH . ? A HOH 206 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 113.5 ?
+181 O     ? L HOH . ? A HOH 211 ? 3_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 101.3 ?
+182 O     ? L HOH . ? A HOH 220 ? 1_555 NA ? G NA . ? A NA 105 ? 1_555 O     ? L HOH . ? A HOH 220 ? 7_555 0.0   ?
+183 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 7.3   ?
+184 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 0.0   ?
+185 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   1 ? B G   1   ? 1_555 7.3   ?
+186 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 7.3   ?
+187 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 0.0   ?
+188 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   1 ? B G   1   ? 1_555 7.3   ?
+189 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 80.6  ?
+190 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 76.0  ?
+191 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 80.6  ?
+192 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 76.0  ?
+193 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 73.9  ?
+194 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 68.8  ?
+195 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 73.9  ?
+196 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 68.8  ?
+197 O6    A B G   3 ? B G   3   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 8.5   ?
+198 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 80.6  ?
+199 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 76.0  ?
+200 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 80.6  ?
+201 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 76.0  ?
+202 O6    A B G   3 ? B G   3   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 0.0   ?
+203 O6    B B G   3 ? B G   3   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    A B G   3 ? B G   3   ? 1_555 8.5   ?
+204 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 73.9  ?
+205 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 68.8  ?
+206 O6    A B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 73.9  ?
+207 O6    B B G   1 ? B G   1   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 68.8  ?
+208 O6    A B G   3 ? B G   3   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 8.5   ?
+209 O6    B B G   3 ? B G   3   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 0.0   ?
+210 O6    A B G   3 ? B G   3   ? 1_555 K  ? J K  . ? B K  103 ? 1_555 O6    B B G   3 ? B G   3   ? 1_555 8.5   ?
+211 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O4    B B U   4 ? B U   4   ? 1_555 1.2   ?
+212 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O4    A B U   4 ? B U   4   ? 1_555 0.0   ?
+213 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O4    A B U   4 ? B U   4   ? 1_555 1.2   ?
+214 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O4    B B U   4 ? B U   4   ? 1_555 1.2   ?
+215 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O4    B B U   4 ? B U   4   ? 1_555 0.0   ?
+216 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O4    B B U   4 ? B U   4   ? 1_555 1.2   ?
+217 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 79.0  ?
+218 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 78.0  ?
+219 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 79.0  ?
+220 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 78.0  ?
+221 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 78.0  ?
+222 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 77.0  ?
+223 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 78.0  ?
+224 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 77.0  ?
+225 O6    A B G   5 ? B G   5   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 1.4   ?
+226 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 79.0  ?
+227 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 78.0  ?
+228 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 79.0  ?
+229 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 78.0  ?
+230 O6    A B G   5 ? B G   5   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 0.0   ?
+231 O6    B B G   5 ? B G   5   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 1.4   ?
+232 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 78.0  ?
+233 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 77.0  ?
+234 O4    A B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 78.0  ?
+235 O4    B B U   4 ? B U   4   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 77.0  ?
+236 O6    A B G   5 ? B G   5   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 1.4   ?
+237 O6    B B G   5 ? B G   5   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 0.0   ?
+238 O6    A B G   5 ? B G   5   ? 1_555 K  ? I K  . ? B K  102 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 1.4   ?
+239 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 2.1   ?
+240 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 0.0   ?
+241 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O6    A B G   5 ? B G   5   ? 1_555 2.1   ?
+242 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 2.1   ?
+243 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 0.0   ?
+244 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O6    B B G   5 ? B G   5   ? 1_555 2.1   ?
+245 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 67.5  ?
+246 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 65.4  ?
+247 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 67.5  ?
+248 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 65.4  ?
+249 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 71.4  ?
+250 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 69.3  ?
+251 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 71.4  ?
+252 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 69.3  ?
+253 O4    A B U   6 ? B U   6   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 5.2   ?
+254 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 67.5  ?
+255 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 65.4  ?
+256 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 67.5  ?
+257 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 65.4  ?
+258 O4    A B U   6 ? B U   6   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 0.0   ?
+259 O4    B B U   6 ? B U   6   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    A B U   6 ? B U   6   ? 1_555 5.2   ?
+260 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 71.4  ?
+261 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 69.3  ?
+262 O6    A B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 71.4  ?
+263 O6    B B G   5 ? B G   5   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 69.3  ?
+264 O4    A B U   6 ? B U   6   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 5.2   ?
+265 O4    B B U   6 ? B U   6   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 0.0   ?
+266 O4    A B U   6 ? B U   6   ? 1_555 K  ? H K  . ? B K  101 ? 1_555 O4    B B U   6 ? B U   6   ? 1_555 5.2   ?
+267 "O3'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 "O2'" A B U   6 ? B U   6   ? 1_555 47.3  ?
+268 "O3'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 "O2'" B B U   6 ? B U   6   ? 1_555 67.7  ?
+269 "O2'" A B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 "O2'" B B U   6 ? B U   6   ? 1_555 22.4  ?
+270 "O3'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     B M HOH . ? B HOH 203 ? 1_555 156.8 ?
+271 "O2'" A B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     B M HOH . ? B HOH 203 ? 1_555 109.4 ?
+272 "O2'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     B M HOH . ? B HOH 203 ? 1_555 89.3  ?
+273 "O3'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     A M HOH . ? B HOH 203 ? 1_555 124.7 ?
+274 "O2'" A B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     A M HOH . ? B HOH 203 ? 1_555 84.3  ?
+275 "O2'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     A M HOH . ? B HOH 203 ? 1_555 61.9  ?
+276 O     B M HOH . ? B HOH 203 ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     A M HOH . ? B HOH 203 ? 1_555 37.6  ?
+277 "O3'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 206 ? 1_555 112.1 ?
+278 "O2'" A B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 206 ? 1_555 87.2  ?
+279 "O2'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 206 ? 1_555 85.2  ?
+280 O     B M HOH . ? B HOH 203 ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 206 ? 1_555 60.5  ?
+281 O     A M HOH . ? B HOH 203 ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 206 ? 1_555 85.4  ?
+282 "O3'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 210 ? 1_555 94.5  ?
+283 "O2'" A B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 210 ? 1_555 98.3  ?
+284 "O2'" B B U   6 ? B U   6   ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 210 ? 1_555 88.0  ?
+285 O     B M HOH . ? B HOH 203 ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 210 ? 1_555 87.6  ?
+286 O     A M HOH . ? B HOH 203 ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 210 ? 1_555 63.5  ?
+287 O     ? M HOH . ? B HOH 206 ? 1_555 NA ? K NA . ? B NA 104 ? 1_555 O     ? M HOH . ? B HOH 210 ? 1_555 147.4 ?
+
+_pdbx_entry_details.entry_id      8VJT
+_pdbx_entry_details.has_ligand_of_interest Y
+_pdbx_entry_details.compound_details ?
+_pdbx_entry_details.source_details ?
+_pdbx_entry_details.nonpolymer_details ?
+_pdbx_entry_details.sequence_details ?
+_pdbx_entry_details.has_protein_modification N
+
+loop_
+_pdbx_validate_rmsd_angle.id
+_pdbx_validate_rmsd_angle.PDB_model_num
+_pdbx_validate_rmsd_angle.auth_atom_id_1
+_pdbx_validate_rmsd_angle.auth_asym_id_1
+_pdbx_validate_rmsd_angle.auth_comp_id_1
+_pdbx_validate_rmsd_angle.auth_seq_id_1
+_pdbx_validate_rmsd_angle.PDB_ins_code_1
+_pdbx_validate_rmsd_angle.label_alt_id_1
+_pdbx_validate_rmsd_angle.auth_atom_id_2
+_pdbx_validate_rmsd_angle.auth_asym_id_2
+_pdbx_validate_rmsd_angle.auth_comp_id_2
+_pdbx_validate_rmsd_angle.auth_seq_id_2
+_pdbx_validate_rmsd_angle.PDB_ins_code_2
+_pdbx_validate_rmsd_angle.label_alt_id_2
+_pdbx_validate_rmsd_angle.auth_atom_id_3
+_pdbx_validate_rmsd_angle.auth_asym_id_3
+_pdbx_validate_rmsd_angle.auth_comp_id_3
+_pdbx_validate_rmsd_angle.auth_seq_id_3
+_pdbx_validate_rmsd_angle.PDB_ins_code_3
+_pdbx_validate_rmsd_angle.label_alt_id_3
+_pdbx_validate_rmsd_angle.angle_value
+_pdbx_validate_rmsd_angle.angle_target_value
+_pdbx_validate_rmsd_angle.angle_deviation
+_pdbx_validate_rmsd_angle.angle_standard_deviation
+_pdbx_validate_rmsd_angle.linker_flag
+1 1 "O4'" B G 3 ? A "C1'" B G 3 ? A N9 B G 3 ? A 113.78 108.50 5.28 0.70 N
+2 1 "O4'" B G 3 ? B "C1'" B G 3 ? B N9 B G 3 ? B 113.71 108.50 5.21 0.70 N
+
+loop_
+_pdbx_struct_special_symmetry.id
+_pdbx_struct_special_symmetry.PDB_model_num
+_pdbx_struct_special_symmetry.auth_asym_id
+_pdbx_struct_special_symmetry.auth_comp_id
+_pdbx_struct_special_symmetry.auth_seq_id
+_pdbx_struct_special_symmetry.PDB_ins_code
+_pdbx_struct_special_symmetry.label_asym_id
+_pdbx_struct_special_symmetry.label_comp_id
+_pdbx_struct_special_symmetry.label_seq_id
+1  1 A K   101 ? C K   .
+2  1 A K   102 ? D K   .
+3  1 A K   103 ? E K   .
+4  1 A K   104 ? F K   .
+5  1 B K   101 ? H K   .
+6  1 B K   102 ? I K   .
+7  1 B K   103 ? J K   .
+8  1 A HOH 207 ? L HOH .
+9  1 A HOH 210 ? L HOH .
+10 1 A HOH 218 ? L HOH .
+11 1 A HOH 220 ? L HOH .
+12 1 A HOH 226 ? L HOH .
+13 1 B HOH 201 ? M HOH .
+
+loop_
+_space_group_symop.id
+_space_group_symop.operation_xyz
+1 x,y,z
+2 -y+1/2,x+1/2,z
+3 y+1/2,-x+1/2,z
+4 x+1/2,-y+1/2,-z
+5 -x+1/2,y+1/2,-z
+6 -x,-y,z
+7 y,x,-z
+8 -y,-x,-z
+
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.type_symbol
+_chem_comp_atom.pdbx_aromatic_flag
+_chem_comp_atom.pdbx_stereo_config
+_chem_comp_atom.pdbx_ordinal
+G   OP3    O  N N 1
+G   P      P  N N 2
+G   OP1    O  N N 3
+G   OP2    O  N N 4
+G   "O5'"  O  N N 5
+G   "C5'"  C  N N 6
+G   "C4'"  C  N R 7
+G   "O4'"  O  N N 8
+G   "C3'"  C  N S 9
+G   "O3'"  O  N N 10
+G   "C2'"  C  N R 11
+G   "O2'"  O  N N 12
+G   "C1'"  C  N R 13
+G   N9     N  Y N 14
+G   C8     C  Y N 15
+G   N7     N  Y N 16
+G   C5     C  Y N 17
+G   C6     C  N N 18
+G   O6     O  N N 19
+G   N1     N  N N 20
+G   C2     C  N N 21
+G   N2     N  N N 22
+G   N3     N  N N 23
+G   C4     C  Y N 24
+G   HOP3   H  N N 25
+G   HOP2   H  N N 26
+G   "H5'"  H  N N 27
+G   "H5''" H  N N 28
+G   "H4'"  H  N N 29
+G   "H3'"  H  N N 30
+G   "HO3'" H  N N 31
+G   "H2'"  H  N N 32
+G   "HO2'" H  N N 33
+G   "H1'"  H  N N 34
+G   H8     H  N N 35
+G   H1     H  N N 36
+G   H21    H  N N 37
+G   H22    H  N N 38
+HOH O      O  N N 39
+HOH H1     H  N N 40
+HOH H2     H  N N 41
+K   K      K  N N 42
+NA  NA     NA N N 43
+U   OP3    O  N N 44
+U   P      P  N N 45
+U   OP1    O  N N 46
+U   OP2    O  N N 47
+U   "O5'"  O  N N 48
+U   "C5'"  C  N N 49
+U   "C4'"  C  N R 50
+U   "O4'"  O  N N 51
+U   "C3'"  C  N S 52
+U   "O3'"  O  N N 53
+U   "C2'"  C  N R 54
+U   "O2'"  O  N N 55
+U   "C1'"  C  N R 56
+U   N1     N  N N 57
+U   C2     C  N N 58
+U   O2     O  N N 59
+U   N3     N  N N 60
+U   C4     C  N N 61
+U   O4     O  N N 62
+U   C5     C  N N 63
+U   C6     C  N N 64
+U   HOP3   H  N N 65
+U   HOP2   H  N N 66
+U   "H5'"  H  N N 67
+U   "H5''" H  N N 68
+U   "H4'"  H  N N 69
+U   "H3'"  H  N N 70
+U   "HO3'" H  N N 71
+U   "H2'"  H  N N 72
+U   "HO2'" H  N N 73
+U   "H1'"  H  N N 74
+U   H3     H  N N 75
+U   H5     H  N N 76
+U   H6     H  N N 77
+
+loop_
+_chem_comp_bond.comp_id
+_chem_comp_bond.atom_id_1
+_chem_comp_bond.atom_id_2
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
+_chem_comp_bond.pdbx_stereo_config
+_chem_comp_bond.pdbx_ordinal
+G   OP3   P      sing N N 1
+G   OP3   HOP3   sing N N 2
+G   P     OP1    doub N N 3
+G   P     OP2    sing N N 4
+G   P     "O5'"  sing N N 5
+G   OP2   HOP2   sing N N 6
+G   "O5'" "C5'"  sing N N 7
+G   "C5'" "C4'"  sing N N 8
+G   "C5'" "H5'"  sing N N 9
+G   "C5'" "H5''" sing N N 10
+G   "C4'" "O4'"  sing N N 11
+G   "C4'" "C3'"  sing N N 12
+G   "C4'" "H4'"  sing N N 13
+G   "O4'" "C1'"  sing N N 14
+G   "C3'" "O3'"  sing N N 15
+G   "C3'" "C2'"  sing N N 16
+G   "C3'" "H3'"  sing N N 17
+G   "O3'" "HO3'" sing N N 18
+G   "C2'" "O2'"  sing N N 19
+G   "C2'" "C1'"  sing N N 20
+G   "C2'" "H2'"  sing N N 21
+G   "O2'" "HO2'" sing N N 22
+G   "C1'" N9     sing N N 23
+G   "C1'" "H1'"  sing N N 24
+G   N9    C8     sing Y N 25
+G   N9    C4     sing Y N 26
+G   C8    N7     doub Y N 27
+G   C8    H8     sing N N 28
+G   N7    C5     sing Y N 29
+G   C5    C6     sing N N 30
+G   C5    C4     doub Y N 31
+G   C6    O6     doub N N 32
+G   C6    N1     sing N N 33
+G   N1    C2     sing N N 34
+G   N1    H1     sing N N 35
+G   C2    N2     sing N N 36
+G   C2    N3     doub N N 37
+G   N2    H21    sing N N 38
+G   N2    H22    sing N N 39
+G   N3    C4     sing N N 40
+HOH O     H1     sing N N 41
+HOH O     H2     sing N N 42
+U   OP3   P      sing N N 43
+U   OP3   HOP3   sing N N 44
+U   P     OP1    doub N N 45
+U   P     OP2    sing N N 46
+U   P     "O5'"  sing N N 47
+U   OP2   HOP2   sing N N 48
+U   "O5'" "C5'"  sing N N 49
+U   "C5'" "C4'"  sing N N 50
+U   "C5'" "H5'"  sing N N 51
+U   "C5'" "H5''" sing N N 52
+U   "C4'" "O4'"  sing N N 53
+U   "C4'" "C3'"  sing N N 54
+U   "C4'" "H4'"  sing N N 55
+U   "O4'" "C1'"  sing N N 56
+U   "C3'" "O3'"  sing N N 57
+U   "C3'" "C2'"  sing N N 58
+U   "C3'" "H3'"  sing N N 59
+U   "O3'" "HO3'" sing N N 60
+U   "C2'" "O2'"  sing N N 61
+U   "C2'" "C1'"  sing N N 62
+U   "C2'" "H2'"  sing N N 63
+U   "O2'" "HO2'" sing N N 64
+U   "C1'" N1     sing N N 65
+U   "C1'" "H1'"  sing N N 66
+U   N1    C2     sing N N 67
+U   N1    C6     sing N N 68
+U   C2    O2     doub N N 69
+U   C2    N3     sing N N 70
+U   N3    C4     sing N N 71
+U   N3    H3     sing N N 72
+U   C4    O4     doub N N 73
+U   C4    C5     sing N N 74
+U   C5    C6     doub N N 75
+U   C5    H5     sing N N 76
+U   C6    H6     sing N N 77
+
+loop_
+_ndb_struct_conf_na.entry_id
+_ndb_struct_conf_na.feature
+8VJT 'double helix'
+8VJT 'triple helix'
+
+loop_
+_ndb_struct_na_base_pair.model_number
+_ndb_struct_na_base_pair.i_label_asym_id
+_ndb_struct_na_base_pair.i_label_comp_id
+_ndb_struct_na_base_pair.i_label_seq_id
+_ndb_struct_na_base_pair.i_symmetry
+_ndb_struct_na_base_pair.j_label_asym_id
+_ndb_struct_na_base_pair.j_label_comp_id
+_ndb_struct_na_base_pair.j_label_seq_id
+_ndb_struct_na_base_pair.j_symmetry
+_ndb_struct_na_base_pair.shear
+_ndb_struct_na_base_pair.stretch
+_ndb_struct_na_base_pair.stagger
+_ndb_struct_na_base_pair.buckle
+_ndb_struct_na_base_pair.propeller
+_ndb_struct_na_base_pair.opening
+_ndb_struct_na_base_pair.pair_number
+_ndb_struct_na_base_pair.pair_name
+_ndb_struct_na_base_pair.i_auth_asym_id
+_ndb_struct_na_base_pair.i_auth_seq_id
+_ndb_struct_na_base_pair.i_PDB_ins_code
+_ndb_struct_na_base_pair.j_auth_asym_id
+_ndb_struct_na_base_pair.j_auth_seq_id
+_ndb_struct_na_base_pair.j_PDB_ins_code
+_ndb_struct_na_base_pair.hbond_type_28
+_ndb_struct_na_base_pair.hbond_type_12
+1 A U 6 3_555 A U 6 1_555 -0.592 -3.014 -0.560 6.383   -21.821 87.683  1  A_U6:U6_A A 6 ? A 6 ? ? 3
+1 A G 5 1_555 A G 5 3_555 -1.788 -3.273 0.139  -15.341 13.135  88.182  2  A_G5:G5_A A 5 ? A 5 ? 6 3
+1 A U 4 3_555 A U 4 1_555 0.373  2.983  0.209  -3.720  8.445   -89.627 3  A_U4:U4_A A 4 ? A 4 ? ? ?
+1 A G 3 1_555 A G 3 3_555 -1.728 -3.511 -0.213 5.108   -9.412  89.497  4  A_G3:G3_A A 3 ? A 3 ? 6 3
+1 A G 1 1_555 A G 1 3_555 -1.442 -3.668 0.062  4.159   0.296   89.924  5  A_G1:G1_A A 1 ? A 1 ? 6 3
+1 A U 6 4_455 A U 6 1_555 0.592  3.014  0.560  -6.383  21.821  -87.683 6  A_U6:U6_A A 6 ? A 6 ? ? 3
+1 A G 5 1_555 A G 5 4_455 1.788  3.273  -0.139 15.341  -13.135 -88.182 7  A_G5:G5_A A 5 ? A 5 ? 6 3
+1 A U 4 4_455 A U 4 1_555 -0.373 -2.983 -0.209 3.720   -8.445  89.627  8  A_U4:U4_A A 4 ? A 4 ? ? ?
+1 A G 3 1_555 A G 3 4_455 1.728  3.511  0.213  -5.108  9.412   -89.497 9  A_G3:G3_A A 3 ? A 3 ? 6 3
+1 A G 1 1_555 A G 1 4_455 1.442  3.668  -0.062 -4.159  -0.296  -89.924 10 A_G1:G1_A A 1 ? A 1 ? 6 3
+1 B U 6 3_555 B U 6 1_555 0.526  2.855  0.584  -22.049 25.729  -84.675 11 B_U6:U6_B B 6 ? B 6 ? ? 3
+1 B G 5 1_555 B G 5 3_555 1.452  3.456  -0.145 9.432   -8.725  -89.274 12 B_G5:G5_B B 5 ? B 5 ? 6 3
+1 B U 4 3_555 B U 4 1_555 -0.447 -3.058 -0.043 4.826   -2.328  89.875  13 B_U4:U4_B B 4 ? B 4 ? ? ?
+1 B G 3 1_555 B G 3 3_555 1.539  3.460  -0.142 5.478   -7.112  -89.647 14 B_G3:G3_B B 3 ? B 3 ? 6 3
+1 B G 1 1_555 B G 1 3_555 1.771  3.128  -0.057 1.507   -2.925  -89.953 15 B_G1:G1_B B 1 ? B 1 ? 6 3
+1 B U 6 4_455 B U 6 1_555 -0.526 -2.855 -0.584 22.049  -25.729 84.675  16 B_U6:U6_B B 6 ? B 6 ? ? 3
+1 B G 5 1_555 B G 5 4_455 -1.452 -3.456 0.145  -9.432  8.725   89.274  17 B_G5:G5_B B 5 ? B 5 ? 6 3
+1 B U 4 4_455 B U 4 1_555 0.447  3.058  0.043  -4.826  2.328   -89.875 18 B_U4:U4_B B 4 ? B 4 ? ? ?
+1 B G 3 1_555 B G 3 4_455 -1.539 -3.460 0.142  -5.478  7.112   89.647  19 B_G3:G3_B B 3 ? B 3 ? 6 3
+1 B G 1 1_555 B G 1 4_455 -1.771 -3.128 0.057  -1.507  2.925   89.953  20 B_G1:G1_B B 1 ? B 1 ? 6 3
+
+loop_
+_ndb_struct_na_base_pair_step.model_number
+_ndb_struct_na_base_pair_step.i_label_asym_id_1
+_ndb_struct_na_base_pair_step.i_label_comp_id_1
+_ndb_struct_na_base_pair_step.i_label_seq_id_1
+_ndb_struct_na_base_pair_step.i_symmetry_1
+_ndb_struct_na_base_pair_step.j_label_asym_id_1
+_ndb_struct_na_base_pair_step.j_label_comp_id_1
+_ndb_struct_na_base_pair_step.j_label_seq_id_1
+_ndb_struct_na_base_pair_step.j_symmetry_1
+_ndb_struct_na_base_pair_step.i_label_asym_id_2
+_ndb_struct_na_base_pair_step.i_label_comp_id_2
+_ndb_struct_na_base_pair_step.i_label_seq_id_2
+_ndb_struct_na_base_pair_step.i_symmetry_2
+_ndb_struct_na_base_pair_step.j_label_asym_id_2
+_ndb_struct_na_base_pair_step.j_label_comp_id_2
+_ndb_struct_na_base_pair_step.j_label_seq_id_2
+_ndb_struct_na_base_pair_step.j_symmetry_2
+_ndb_struct_na_base_pair_step.shift
+_ndb_struct_na_base_pair_step.slide
+_ndb_struct_na_base_pair_step.rise
+_ndb_struct_na_base_pair_step.tilt
+_ndb_struct_na_base_pair_step.roll
+_ndb_struct_na_base_pair_step.twist
+_ndb_struct_na_base_pair_step.x_displacement
+_ndb_struct_na_base_pair_step.y_displacement
+_ndb_struct_na_base_pair_step.helical_rise
+_ndb_struct_na_base_pair_step.inclination
+_ndb_struct_na_base_pair_step.tip
+_ndb_struct_na_base_pair_step.helical_twist
+_ndb_struct_na_base_pair_step.step_number
+_ndb_struct_na_base_pair_step.step_name
+_ndb_struct_na_base_pair_step.i_auth_asym_id_1
+_ndb_struct_na_base_pair_step.i_auth_seq_id_1
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_1
+_ndb_struct_na_base_pair_step.j_auth_asym_id_1
+_ndb_struct_na_base_pair_step.j_auth_seq_id_1
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_1
+_ndb_struct_na_base_pair_step.i_auth_asym_id_2
+_ndb_struct_na_base_pair_step.i_auth_seq_id_2
+_ndb_struct_na_base_pair_step.i_PDB_ins_code_2
+_ndb_struct_na_base_pair_step.j_auth_asym_id_2
+_ndb_struct_na_base_pair_step.j_auth_seq_id_2
+_ndb_struct_na_base_pair_step.j_PDB_ins_code_2
+1 A U 6 3_555 A U 6 1_555 A G 5 1_555 A G 5 3_555 2.454  2.097 -2.222 49.509 -166.457 -56.518 -1.658 1.048  0.100  84.826 25.230  -174.419 1  AA_U6G5:G5U6_AA A 6 ? A 6 ? A 5 ? A 5 ?
+1 A G 5 1_555 A G 5 3_555 A U 4 3_555 A U 4 1_555 0.580  0.008 -2.756 -9.305 -9.959   -26.090 -1.761 2.776  -2.270 20.385 -19.046 -29.381  2  AA_G5U4:U4G5_AA A 5 ? A 5 ? A 4 ? A 4 ?
+1 A U 4 3_555 A U 4 1_555 A G 3 1_555 A G 3 3_555 -0.045 1.931 -3.406 -1.858 2.152    -36.552 -2.758 0.197  -3.508 -3.426 -2.957  -36.659  3  AA_U4G3:G3U4_AA A 4 ? A 4 ? A 3 ? A 3 ?
+1 A G 3 1_555 A G 3 3_555 A G 1 1_555 A G 1 3_555 0.472  1.636 -3.374 2.204  2.528    -54.548 -1.623 0.375  -3.456 -2.756 2.402   -54.643  4  AA_G3G1:G1G3_AA A 3 ? A 3 ? A 1 ? A 1 ?
+1 A U 6 4_455 A U 6 1_555 A G 5 1_555 A G 5 4_455 2.454  2.097 -2.222 49.509 -166.457 -56.518 -1.658 1.048  0.100  84.826 25.230  -174.419 5  AA_U6G5:G5U6_AA A 6 ? A 6 ? A 5 ? A 5 ?
+1 A G 5 1_555 A G 5 4_455 A U 4 4_455 A U 4 1_555 0.580  0.008 -2.756 -9.305 -9.959   -26.090 -1.761 2.776  -2.270 20.385 -19.046 -29.381  6  AA_G5U4:U4G5_AA A 5 ? A 5 ? A 4 ? A 4 ?
+1 A U 4 4_455 A U 4 1_555 A G 3 1_555 A G 3 4_455 -0.045 1.931 -3.406 -1.858 2.152    -36.552 -2.758 0.197  -3.508 -3.426 -2.957  -36.659  7  AA_U4G3:G3U4_AA A 4 ? A 4 ? A 3 ? A 3 ?
+1 A G 3 1_555 A G 3 4_455 A G 1 1_555 A G 1 4_455 0.472  1.636 -3.374 2.204  2.528    -54.548 -1.623 0.375  -3.456 -2.756 2.402   -54.643  8  AA_G3G1:G1G3_AA A 3 ? A 3 ? A 1 ? A 1 ?
+1 B U 6 3_555 B U 6 1_555 B G 5 1_555 B G 5 3_555 1.841  2.918 -1.786 56.789 -155.696 -98.877 -1.772 0.811  0.005  79.448 28.978  -170.734 9  BB_U6G5:G5U6_BB B 6 ? B 6 ? B 5 ? B 5 ?
+1 B G 5 1_555 B G 5 3_555 B U 4 3_555 B U 4 1_555 0.533  0.312 -3.033 -4.778 -7.747   -29.531 -1.947 1.841  -2.747 14.762 -9.106  -30.872  10 BB_G5U4:U4G5_BB B 5 ? B 5 ? B 4 ? B 4 ?
+1 B U 4 3_555 B U 4 1_555 B G 3 1_555 B G 3 3_555 0.063  1.358 -3.749 4.619  4.224    -34.401 -1.514 -0.713 -3.859 -7.069 7.731   -34.949  11 BB_U4G3:G3U4_BB B 4 ? B 4 ? B 3 ? B 3 ?
+1 B G 3 1_555 B G 3 3_555 B G 1 1_555 B G 1 3_555 0.794  1.035 -3.247 -0.891 -3.480   -36.766 -2.092 1.370  -3.120 5.501  -1.409  -36.935  12 BB_G3G1:G1G3_BB B 3 ? B 3 ? B 1 ? B 1 ?
+1 B U 6 4_455 B U 6 1_555 B G 5 1_555 B G 5 4_455 1.841  2.918 -1.786 56.789 -155.696 -98.877 -1.772 0.811  0.005  79.448 28.978  -170.734 13 BB_U6G5:G5U6_BB B 6 ? B 6 ? B 5 ? B 5 ?
+1 B G 5 1_555 B G 5 4_455 B U 4 4_455 B U 4 1_555 0.533  0.312 -3.033 -4.778 -7.747   -29.531 -1.947 1.841  -2.747 14.762 -9.106  -30.872  14 BB_G5U4:U4G5_BB B 5 ? B 5 ? B 4 ? B 4 ?
+1 B U 4 4_455 B U 4 1_555 B G 3 1_555 B G 3 4_455 0.063  1.358 -3.749 4.619  4.224    -34.401 -1.514 -0.713 -3.859 -7.069 7.731   -34.949  15 BB_U4G3:G3U4_BB B 4 ? B 4 ? B 3 ? B 3 ?
+1 B G 3 1_555 B G 3 4_455 B G 1 1_555 B G 1 4_455 0.794  1.035 -3.247 -0.891 -3.480   -36.766 -2.092 1.370  -3.120 5.501  -1.409  -36.935  16 BB_G3G1:G1G3_BB B 3 ? B 3 ? B 1 ? B 1 ?
+
+_pdbx_audit_support.funding_organization
+'National Institutes of Health/National Institute of General Medical Sciences (NIH/NIGMS)'
+_pdbx_audit_support.country       'United States'
+_pdbx_audit_support.grant_number  2R35GM118131-06
+_pdbx_audit_support.ordinal       1
+
+_space_group.name_H-M_alt         'P 4 21 2'
+_space_group.name_Hall            'P 4ab 2ab'
+_space_group.IT_number            90
+_space_group.crystal_system       tetragonal
+_space_group.id                   1
+
+_atom_sites.entry_id              8VJT
+_atom_sites.Cartn_transf_matrix[1][1] ?
+_atom_sites.Cartn_transf_matrix[1][2] ?
+_atom_sites.Cartn_transf_matrix[1][3] ?
+_atom_sites.Cartn_transf_matrix[2][1] ?
+_atom_sites.Cartn_transf_matrix[2][2] ?
+_atom_sites.Cartn_transf_matrix[2][3] ?
+_atom_sites.Cartn_transf_matrix[3][1] ?
+_atom_sites.Cartn_transf_matrix[3][2] ?
+_atom_sites.Cartn_transf_matrix[3][3] ?
+_atom_sites.Cartn_transf_vector[1] ?
+_atom_sites.Cartn_transf_vector[2] ?
+_atom_sites.Cartn_transf_vector[3] ?
+_atom_sites.Cartn_transform_axes  ?
+_atom_sites.fract_transf_matrix[1][1] 0.030468
+_atom_sites.fract_transf_matrix[1][2] 0.000000
+_atom_sites.fract_transf_matrix[1][3] 0.000000
+_atom_sites.fract_transf_matrix[2][1] 0.000000
+_atom_sites.fract_transf_matrix[2][2] 0.030468
+_atom_sites.fract_transf_matrix[2][3] 0.000000
+_atom_sites.fract_transf_matrix[3][1] 0.000000
+_atom_sites.fract_transf_matrix[3][2] 0.000000
+_atom_sites.fract_transf_matrix[3][3] 0.017250
+_atom_sites.fract_transf_vector[1] 0.00000
+_atom_sites.fract_transf_vector[2] 0.00000
+_atom_sites.fract_transf_vector[3] 0.00000
+_atom_sites.solution_primary      ?
+_atom_sites.solution_secondary    ?
+_atom_sites.solution_hydrogens    ?
+_atom_sites.special_details       ?
+
+loop_
+_atom_type.symbol
+_atom_type.scat_dispersion_real
+_atom_type.scat_dispersion_imag
+_atom_type.scat_Cromer_Mann_a1
+_atom_type.scat_Cromer_Mann_a2
+_atom_type.scat_Cromer_Mann_a3
+_atom_type.scat_Cromer_Mann_a4
+_atom_type.scat_Cromer_Mann_b1
+_atom_type.scat_Cromer_Mann_b2
+_atom_type.scat_Cromer_Mann_b3
+_atom_type.scat_Cromer_Mann_b4
+_atom_type.scat_Cromer_Mann_c
+_atom_type.scat_source
+_atom_type.scat_dispersion_source
+C  ? ? 3.54356 2.42580 ?       ? 25.62398 1.50364  ?         ? 0.0 "2-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+H  ? ? 0.53795 0.34799 0.11320 ? 10.08003 29.74760 2.57510   ? 0.0 "3-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+K  ? ? 8.66788 8.58341 1.68052 ? 12.31593 0.56275  110.00227 ? 0.0 "3-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+N  ? ? 4.01032 2.96436 ?       ? 19.97189 1.75589  ?         ? 0.0 "2-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+NA ? ? 6.63511 3.01293 1.30238 ? 5.54423  0.54580  90.85902  ? 0.0 "3-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+O  ? ? 4.49882 3.47563 ?       ? 15.80542 1.70748  ?         ? 0.0 "2-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+P  ? ? 9.51135 5.44231 ?       ? 1.42069  35.72801 ?         ? 0.0 "2-Gaussianfit: Grosse-Kunstleve RW, Sauter NK, Adams PD: Newsletter of the IUCr Commission on Crystallographic Computing 2004, 3, 22-31." ?
+
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_alt_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_entity_id
+_atom_site.label_seq_id
+_atom_site.pdbx_PDB_ins_code
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+_atom_site.occupancy
+_atom_site.B_iso_or_equiv
+_atom_site.pdbx_formal_charge
+_atom_site.auth_seq_id
+_atom_site.auth_comp_id
+_atom_site.auth_asym_id
+_atom_site.auth_atom_id
+_atom_site.pdbx_PDB_model_num
+ATOM   1   O  "O5'"  A G   A 1 1 ? 8.99859  15.83324 10.85196 0.522 49.78332 ? 1   G   A "O5'"  1
+ATOM   2   O  "O5'"  B G   A 1 1 ? 8.14479  16.64724 9.25456  0.478 9.85620  ? 1   G   A "O5'"  1
+ATOM   3   C  "C5'"  A G   A 1 1 ? 8.65442  17.08378 10.26282 0.522 44.78424 ? 1   G   A "C5'"  1
+ATOM   4   C  "C5'"  B G   A 1 1 ? 8.52429  16.51679 10.61075 0.478 8.95934  ? 1   G   A "C5'"  1
+ATOM   5   C  "C4'"  A G   A 1 1 ? 9.17447  18.25677 11.06170 0.522 36.70098 ? 1   G   A "C4'"  1
+ATOM   6   C  "C4'"  B G   A 1 1 ? 9.03148  17.81903 11.17176 0.478 9.10539  ? 1   G   A "C4'"  1
+ATOM   7   O  "O4'"  A G   A 1 1 ? 8.09054  19.18800 11.26719 0.522 30.73681 ? 1   G   A "O4'"  1
+ATOM   8   O  "O4'"  B G   A 1 1 ? 7.95405  18.78008 11.20576 0.478 9.59011  ? 1   G   A "O4'"  1
+ATOM   9   C  "C3'"  A G   A 1 1 ? 9.70299  17.92272 12.44506 0.522 33.07235 ? 1   G   A "C3'"  1
+ATOM   10  C  "C3'"  B G   A 1 1 ? 9.54822  17.74300 12.59196 0.478 10.04168 ? 1   G   A "C3'"  1
+ATOM   11  O  "O3'"  A G   A 1 1 ? 10.72823 18.83497 12.80403 0.522 30.02718 ? 1   G   A "O3'"  1
+ATOM   12  O  "O3'"  B G   A 1 1 ? 10.49868 18.76036 12.73253 0.478 10.04765 ? 1   G   A "O3'"  1
+ATOM   13  C  "C2'"  A G   A 1 1 ? 8.48770  18.11619 13.34524 0.522 31.30443 ? 1   G   A "C2'"  1
+ATOM   14  C  "C2'"  B G   A 1 1 ? 8.32432  18.05867 13.42717 0.478 9.61386  ? 1   G   A "C2'"  1
+ATOM   15  O  "O2'"  A G   A 1 1 ? 8.79139  18.49330 14.67236 0.522 34.28313 ? 1   G   A "O2'"  1
+ATOM   16  O  "O2'"  B G   A 1 1 ? 8.54978  18.64535 14.68426 0.478 10.85336 ? 1   G   A "O2'"  1
+ATOM   17  C  "C1'"  A G   A 1 1 ? 7.72099  19.22587 12.63902 0.522 26.29526 ? 1   G   A "C1'"  1
+ATOM   18  C  "C1'"  B G   A 1 1 ? 7.61469  19.06113 12.56832 0.478 6.36630  ? 1   G   A "C1'"  1
+ATOM   19  N  N9     A G   A 1 1 ? 6.27048  19.03870 12.65550 0.522 17.31324 ? 1   G   A N9     1
+ATOM   20  N  N9     B G   A 1 1 ? 6.17428  18.96743 12.69747 0.478 5.70189  ? 1   G   A N9     1
+ATOM   21  C  C8     A G   A 1 1 ? 5.37600  20.06707 12.56456 0.522 15.92330 ? 1   G   A C8     1
+ATOM   22  C  C8     B G   A 1 1 ? 5.32606  20.02033 12.75358 0.478 5.80001  ? 1   G   A C8     1
+ATOM   23  N  N7     A G   A 1 1 ? 4.14046  19.67463 12.53783 0.522 14.08049 ? 1   G   A N7     1
+ATOM   24  N  N7     B G   A 1 1 ? 4.07378  19.67298 12.79354 0.478 5.33839  ? 1   G   A N7     1
+ATOM   25  C  C5     A G   A 1 1 ? 4.21966  18.29168 12.59119 0.522 11.99944 ? 1   G   A C5     1
+ATOM   26  C  C5     B G   A 1 1 ? 4.10379  18.28792 12.74137 0.478 5.53634  ? 1   G   A C5     1
+ATOM   27  C  C6     A G   A 1 1 ? 3.17270  17.33652 12.57136 0.522 9.52190  ? 1   G   A C6     1
+ATOM   28  C  C6     B G   A 1 1 ? 3.03694  17.34970 12.72745 0.478 6.71715  ? 1   G   A C6     1
+ATOM   29  O  O6     A G   A 1 1 ? 1.95327  17.53848 12.50700 0.522 7.91964  ? 1   G   A O6     1
+ATOM   30  O  O6     B G   A 1 1 ? 1.82342  17.58080 12.77134 0.478 8.06356  ? 1   G   A O6     1
+ATOM   31  N  N1     A G   A 1 1 ? 3.66446  16.04158 12.62709 0.522 9.90420  ? 1   G   A N1     1
+ATOM   32  N  N1     B G   A 1 1 ? 3.50264  16.04453 12.66434 0.478 7.17615  ? 1   G   A N1     1
+ATOM   33  C  C2     A G   A 1 1 ? 4.99423  15.70756 12.69065 0.522 8.71079  ? 1   G   A C2     1
+ATOM   34  C  C2     B G   A 1 1 ? 4.83364  15.69295 12.61174 0.478 8.50208  ? 1   G   A C2     1
+ATOM   35  N  N2     A G   A 1 1 ? 5.25356  14.40049 12.77099 0.522 8.43429  ? 1   G   A N2     1
+ATOM   36  N  N2     B G   A 1 1 ? 5.10031  14.38421 12.57133 0.478 9.51404  ? 1   G   A N2     1
+ATOM   37  N  N3     A G   A 1 1 ? 5.96729  16.58979 12.70856 0.522 10.67793 ? 1   G   A N3     1
+ATOM   38  N  N3     B G   A 1 1 ? 5.82695  16.55887 12.62239 0.478 8.29319  ? 1   G   A N3     1
+ATOM   39  C  C4     A G   A 1 1 ? 5.52390  17.86905 12.64436 0.522 13.25090 ? 1   G   A C4     1
+ATOM   40  C  C4     B G   A 1 1 ? 5.38877  17.83713 12.67840 0.478 6.00643  ? 1   G   A C4     1
+ATOM   41  H  "H5'"  A G   A 1 1 ? 7.68830  17.14770 10.20428 0.522 53.74745 ? 1   G   A "H5'"  1
+ATOM   42  H  "H5'"  B G   A 1 1 ? 9.22335  15.84801 10.68106 0.478 10.75757 ? 1   G   A "H5'"  1
+ATOM   43  H  "H5''" A G   A 1 1 ? 9.02826  17.12279 9.36860  0.522 53.74745 ? 1   G   A "H5''" 1
+ATOM   44  H  "H5''" B G   A 1 1 ? 7.75662  16.22677 11.12792 0.478 10.75757 ? 1   G   A "H5''" 1
+ATOM   45  H  "H4'"  A G   A 1 1 ? 9.88165  18.68986 10.55848 0.522 44.04753 ? 1   G   A "H4'"  1
+ATOM   46  H  "H4'"  B G   A 1 1 ? 9.73191  18.15305 10.58976 0.478 10.93283 ? 1   G   A "H4'"  1
+ATOM   47  H  "H3'"  A G   A 1 1 ? 10.01898 17.00648 12.48439 0.522 39.69319 ? 1   G   A "H3'"  1
+ATOM   48  H  "H3'"  B G   A 1 1 ? 9.89271  16.86632 12.82362 0.478 12.05638 ? 1   G   A "H3'"  1
+ATOM   49  H  "H2'"  A G   A 1 1 ? 7.96617  17.29843 13.33218 0.522 37.57168 ? 1   G   A "H2'"  1
+ATOM   50  H  "H2'"  B G   A 1 1 ? 7.83162  17.22843 13.52130 0.478 11.54300 ? 1   G   A "H2'"  1
+ATOM   51  H  "HO2'" A G   A 1 1 ? 9.15865  17.84677 15.06314 0.522 41.14612 ? 1   G   A "HO2'" 1
+ATOM   52  H  "HO2'" B G   A 1 1 ? 8.86557  18.06579 15.20386 0.478 13.03039 ? 1   G   A "HO2'" 1
+ATOM   53  H  "H1'"  A G   A 1 1 ? 7.98270  20.07102 13.03667 0.522 31.56067 ? 1   G   A "H1'"  1
+ATOM   54  H  "H1'"  B G   A 1 1 ? 7.93354  19.95313 12.77707 0.478 7.64593  ? 1   G   A "H1'"  1
+ATOM   55  H  H8     A G   A 1 1 ? 5.62851  20.96129 12.52563 0.522 19.11432 ? 1   G   A H8     1
+ATOM   56  H  H8     B G   A 1 1 ? 5.61094  20.90557 12.76266 0.478 6.96637  ? 1   G   A H8     1
+ATOM   57  H  H1     A G   A 1 1 ? 3.09307  15.39887 12.62139 0.522 11.89139 ? 1   G   A H1     1
+ATOM   58  H  H1     B G   A 1 1 ? 2.92059  15.41147 12.65759 0.478 8.61775  ? 1   G   A H1     1
+ATOM   59  H  H21    A G   A 1 1 ? 4.60799  13.83244 12.75826 0.522 10.12750 ? 1   G   A H21    1
+ATOM   60  H  H21    B G   A 1 1 ? 4.45640  13.81419 12.56418 0.478 11.42320 ? 1   G   A H21    1
+ATOM   61  H  H22    A G   A 1 1 ? 6.06619  14.12650 12.83548 0.522 10.12750 ? 1   G   A H22    1
+ATOM   62  H  H22    B G   A 1 1 ? 5.91585  14.11193 12.55246 0.478 11.42320 ? 1   G   A H22    1
+ATOM   63  H  "HO5'" A G   A 1 1 ? 8.58240  15.56247 11.53042 0.522 59.74635 ? 1   G   A "HO5'" 1
+ATOM   64  H  "HO5'" B G   A 1 1 ? 7.42437  16.29828 8.99163  0.478 11.83381 ? 1   G   A "HO5'" 1
+ATOM   65  P  P      A U   A 1 2 ? 11.99371 18.28039 13.60412 0.522 27.48704 ? 2   U   A P      1
+ATOM   66  P  P      B U   A 1 2 ? 11.92497 18.35665 13.26183 0.478 14.56554 ? 2   U   A P      1
+ATOM   67  O  OP1    A U   A 1 2 ? 11.51283 17.41268 14.70723 0.522 29.37915 ? 2   U   A OP1    1
+ATOM   68  O  OP1    B U   A 1 2 ? 11.78837 17.73003 14.59506 0.478 17.51984 ? 2   U   A OP1    1
+ATOM   69  O  OP2    A U   A 1 2 ? 12.89648 19.42823 13.87252 0.522 27.24631 ? 2   U   A OP2    1
+ATOM   70  O  OP2    B U   A 1 2 ? 12.76232 19.57113 13.10893 0.478 15.50382 ? 2   U   A OP2    1
+ATOM   71  O  "O5'"  A U   A 1 2 ? 12.70112 17.32276 12.55310 0.522 23.52552 ? 2   U   A "O5'"  1
+ATOM   72  O  "O5'"  B U   A 1 2 ? 12.37761 17.15923 12.30662 0.478 13.95251 ? 2   U   A "O5'"  1
+ATOM   73  C  "C5'"  A U   A 1 2 ? 12.79126 17.68646 11.18505 0.522 18.99538 ? 2   U   A "C5'"  1
+ATOM   74  C  "C5'"  B U   A 1 2 ? 12.70338 17.37176 10.94004 0.478 12.96812 ? 2   U   A "C5'"  1
+ATOM   75  C  "C4'"  A U   A 1 2 ? 13.33856 16.55217 10.36520 0.522 16.98221 ? 2   U   A "C4'"  1
+ATOM   76  C  "C4'"  B U   A 1 2 ? 13.32155 16.14753 10.30911 0.478 14.54681 ? 2   U   A "C4'"  1
+ATOM   77  O  "O4'"  A U   A 1 2 ? 14.60355 16.12303 10.93517 0.522 18.08071 ? 2   U   A "O4'"  1
+ATOM   78  O  "O4'"  B U   A 1 2 ? 14.60130 15.87496 10.93532 0.478 16.04702 ? 2   U   A "O4'"  1
+ATOM   79  C  "C3'"  A U   A 1 2 ? 12.44367 15.31453 10.32793 0.522 15.24615 ? 2   U   A "C3'"  1
+ATOM   80  C  "C3'"  B U   A 1 2 ? 12.51541 14.85430 10.43599 0.478 13.68709 ? 2   U   A "C3'"  1
+ATOM   81  O  "O3'"  A U   A 1 2 ? 12.51717 14.68893 9.05210  0.522 13.42979 ? 2   U   A "O3'"  1
+ATOM   82  O  "O3'"  B U   A 1 2 ? 12.77003 14.01570 9.31717  0.478 14.91952 ? 2   U   A "O3'"  1
+ATOM   83  C  "C2'"  A U   A 1 2 ? 13.07170 14.40355 11.37065 0.522 16.95588 ? 2   U   A "C2'"  1
+ATOM   84  C  "C2'"  B U   A 1 2 ? 13.14755 14.18734 11.63738 0.478 15.21132 ? 2   U   A "C2'"  1
+ATOM   85  O  "O2'"  A U   A 1 2 ? 12.82567 13.02795 11.17245 0.522 17.13474 ? 2   U   A "O2'"  1
+ATOM   86  O  "O2'"  B U   A 1 2 ? 12.96187 12.79062 11.69184 0.478 17.38190 ? 2   U   A "O2'"  1
+ATOM   87  C  "C1'"  A U   A 1 2 ? 14.55085 14.73919 11.21587 0.522 19.03073 ? 2   U   A "C1'"  1
+ATOM   88  C  "C1'"  B U   A 1 2 ? 14.60827 14.54565 11.41415 0.478 15.10868 ? 2   U   A "C1'"  1
+ATOM   89  N  N1     A U   A 1 2 ? 15.35188 14.47596 12.41620 0.522 21.59066 ? 2   U   A N1     1
+ATOM   90  N  N1     B U   A 1 2 ? 15.42422 14.49242 12.61835 0.478 14.74374 ? 2   U   A N1     1
+ATOM   91  C  C2     A U   A 1 2 ? 16.61151 13.93168 12.25000 0.522 23.88650 ? 2   U   A C2     1
+ATOM   92  C  C2     B U   A 1 2 ? 16.68501 13.94006 12.48703 0.478 13.50245 ? 2   U   A C2     1
+ATOM   93  O  O2     A U   A 1 2 ? 17.08318 13.67275 11.15352 0.522 24.11795 ? 2   U   A O2     1
+ATOM   94  O  O2     B U   A 1 2 ? 17.09761 13.50260 11.42456 0.478 13.39272 ? 2   U   A O2     1
+ATOM   95  N  N3     A U   A 1 2 ? 17.29717 13.71629 13.41934 0.522 25.40727 ? 2   U   A N3     1
+ATOM   96  N  N3     B U   A 1 2 ? 17.42220 13.92704 13.64394 0.478 16.21829 ? 2   U   A N3     1
+ATOM   97  C  C4     A U   A 1 2 ? 16.85651 13.97595 14.70233 0.522 26.64153 ? 2   U   A C4     1
+ATOM   98  C  C4     B U   A 1 2 ? 17.02357 14.40404 14.87528 0.478 17.82813 ? 2   U   A C4     1
+ATOM   99  O  O4     A U   A 1 2 ? 17.57815 13.72647 15.66693 0.522 28.24040 ? 2   U   A O4     1
+ATOM   100 O  O4     B U   A 1 2 ? 17.76812 14.33554 15.84546 0.478 19.58066 ? 2   U   A O4     1
+ATOM   101 C  C5     A U   A 1 2 ? 15.54331 14.53333 14.78722 0.522 25.63410 ? 2   U   A C5     1
+ATOM   102 C  C5     B U   A 1 2 ? 15.71017 14.96254 14.91589 0.478 19.00206 ? 2   U   A C5     1
+ATOM   103 C  C6     A U   A 1 2 ? 14.85825 14.75716 13.66583 0.522 23.98291 ? 2   U   A C6     1
+ATOM   104 C  C6     B U   A 1 2 ? 14.97424 14.99414 13.80739 0.478 17.71280 ? 2   U   A C6     1
+ATOM   105 H  "H5'"  A U   A 1 2 ? 13.37541 18.45578 11.09661 0.522 22.80081 ? 2   U   A "H5'"  1
+ATOM   106 H  "H5'"  B U   A 1 2 ? 13.33016 18.10934 10.87666 0.478 15.56811 ? 2   U   A "H5'"  1
+ATOM   107 H  "H5''" A U   A 1 2 ? 11.90873 17.92077 10.85773 0.522 22.80081 ? 2   U   A "H5''" 1
+ATOM   108 H  "H5''" B U   A 1 2 ? 11.89507 17.60169 10.45561 0.478 15.56811 ? 2   U   A "H5''" 1
+ATOM   109 H  "H4'"  A U   A 1 2 ? 13.49977 16.85734 9.45867  0.522 20.38501 ? 2   U   A "H4'"  1
+ATOM   110 H  "H4'"  B U   A 1 2 ? 13.46387 16.33493 9.36809  0.478 17.46253 ? 2   U   A "H4'"  1
+ATOM   111 H  "H3'"  A U   A 1 2 ? 11.52982 15.54642 10.55597 0.522 18.30175 ? 2   U   A "H3'"  1
+ATOM   112 H  "H3'"  B U   A 1 2 ? 11.57283 15.05039 10.55435 0.478 16.43087 ? 2   U   A "H3'"  1
+ATOM   113 H  "H2'"  A U   A 1 2 ? 12.76898 14.66486 12.25437 0.522 20.35342 ? 2   U   A "H2'"  1
+ATOM   114 H  "H2'"  B U   A 1 2 ? 12.82086 14.59073 12.45680 0.478 18.25994 ? 2   U   A "H2'"  1
+ATOM   115 H  "HO2'" A U   A 1 2 ? 11.99672 12.89319 11.18924 0.522 20.56805 ? 2   U   A "HO2'" 1
+ATOM   116 H  "HO2'" B U   A 1 2 ? 12.14074 12.62626 11.75769 0.478 20.86464 ? 2   U   A "HO2'" 1
+ATOM   117 H  "H1'"  A U   A 1 2 ? 14.92129 14.24516 10.46781 0.522 22.84324 ? 2   U   A "H1'"  1
+ATOM   118 H  "H1'"  B U   A 1 2 ? 14.99162 13.95971 10.74286 0.478 18.13677 ? 2   U   A "H1'"  1
+ATOM   119 H  H3     A U   A 1 2 ? 18.08673 13.38359 13.34512 0.522 30.49508 ? 2   U   A H3     1
+ATOM   120 H  H3     B U   A 1 2 ? 18.21108 13.58785 13.59679 0.478 19.46831 ? 2   U   A H3     1
+ATOM   121 H  H5     A U   A 1 2 ? 15.17121 14.73739 15.61475 0.522 30.76728 ? 2   U   A H5     1
+ATOM   122 H  H5     B U   A 1 2 ? 15.37086 15.30230 15.71234 0.478 22.80883 ? 2   U   A H5     1
+ATOM   123 H  H6     A U   A 1 2 ? 14.00513 15.12122 13.73331 0.522 28.78585 ? 2   U   A H6     1
+ATOM   124 H  H6     B U   A 1 2 ? 14.12458 15.37056 13.84311 0.478 21.26172 ? 2   U   A H6     1
+ATOM   125 P  P      A G   A 1 3 ? 11.24694 14.66922 8.09256  0.522 11.58339 ? 3   G   A P      1
+ATOM   126 P  P      B G   A 1 3 ? 11.70588 13.87963 8.14377  0.478 14.94437 ? 3   G   A P      1
+ATOM   127 O  OP1    A G   A 1 3 ? 11.69363 14.25374 6.73821  0.522 13.25123 ? 3   G   A OP1    1
+ATOM   128 O  OP1    B G   A 1 3 ? 12.32776 13.13874 7.01934  0.478 18.39375 ? 3   G   A OP1    1
+ATOM   129 O  OP2    A G   A 1 3 ? 10.53995 15.95580 8.22478  0.522 11.55394 ? 3   G   A OP2    1
+ATOM   130 O  OP2    B G   A 1 3 ? 11.09076 15.22325 7.93618  0.478 17.02162 ? 3   G   A OP2    1
+ATOM   131 O  "O5'"  A G   A 1 3 ? 10.35339 13.52478 8.71940  0.522 10.48525 ? 3   G   A "O5'"  1
+ATOM   132 O  "O5'"  B G   A 1 3 ? 10.59619 12.92461 8.74445  0.478 14.92997 ? 3   G   A "O5'"  1
+ATOM   133 C  "C5'"  A G   A 1 3 ? 9.26556  12.98987 8.01602  0.522 10.84811 ? 3   G   A "C5'"  1
+ATOM   134 C  "C5'"  B G   A 1 3 ? 9.37359  12.77362 8.06330  0.478 15.48116 ? 3   G   A "C5'"  1
+ATOM   135 C  "C4'"  A G   A 1 3 ? 8.66729  11.81912 8.73669  0.522 9.69276  ? 3   G   A "C4'"  1
+ATOM   136 C  "C4'"  B G   A 1 3 ? 8.55467  11.67631 8.66099  0.478 14.14778 ? 3   G   A "C4'"  1
+ATOM   137 O  "O4'"  A G   A 1 3 ? 8.08026  12.25341 9.98600  0.522 9.10465  ? 3   G   A "O4'"  1
+ATOM   138 O  "O4'"  B G   A 1 3 ? 7.85620  12.16470 9.83352  0.478 12.73858 ? 3   G   A "O4'"  1
+ATOM   139 C  "C3'"  A G   A 1 3 ? 7.52145  11.19996 7.95922  0.522 8.72899  ? 3   G   A "C3'"  1
+ATOM   140 C  "C3'"  B G   A 1 3 ? 7.44834  11.17265 7.75842  0.478 14.84886 ? 3   G   A "C3'"  1
+ATOM   141 O  "O3'"  A G   A 1 3 ? 7.97906  10.22476 7.05415  0.522 8.01961  ? 3   G   A "O3'"  1
+ATOM   142 O  "O3'"  B G   A 1 3 ? 7.91714  10.23855 6.82043  0.478 15.67863 ? 3   G   A "O3'"  1
+ATOM   143 C  "C2'"  A G   A 1 3 ? 6.60204  10.68763 9.04481  0.522 9.23009  ? 3   G   A "C2'"  1
+ATOM   144 C  "C2'"  B G   A 1 3 ? 6.45601  10.61670 8.75197  0.478 14.81581 ? 3   G   A "C2'"  1
+ATOM   145 O  "O2'"  A G   A 1 3 ? 7.08919  9.47999  9.60258  0.522 10.88755 ? 3   G   A "O2'"  1
+ATOM   146 O  "O2'"  B G   A 1 3 ? 6.94298  9.41281  9.31959  0.478 15.33855 ? 3   G   A "O2'"  1
+ATOM   147 C  "C1'"  A G   A 1 3 ? 6.75719  11.79321 10.06505 0.522 8.26440  ? 3   G   A "C1'"  1
+ATOM   148 C  "C1'"  B G   A 1 3 ? 6.53086  11.68273 9.82281  0.478 12.02812 ? 3   G   A "C1'"  1
+ATOM   149 N  N9     A G   A 1 3 ? 5.89042  12.94699 9.79951  0.522 9.42873  ? 3   G   A N9     1
+ATOM   150 N  N9     B G   A 1 3 ? 5.63190  12.82415 9.57904  0.478 8.87379  ? 3   G   A N9     1
+ATOM   151 C  C8     A G   A 1 3 ? 6.26107  14.27383 9.78652  0.522 10.16326 ? 3   G   A C8     1
+ATOM   152 C  C8     B G   A 1 3 ? 6.00856  14.14141 9.50385  0.478 7.75259  ? 3   G   A C8     1
+ATOM   153 N  N7     A G   A 1 3 ? 5.24876  15.06631 9.60399  0.522 10.09352 ? 3   G   A N7     1
+ATOM   154 N  N7     B G   A 1 3 ? 4.99580  14.94448 9.35018  0.478 7.38197  ? 3   G   A N7     1
+ATOM   155 C  C5     A G   A 1 3 ? 4.15446  14.20479 9.52238  0.522 9.09583  ? 3   G   A C5     1
+ATOM   156 C  C5     B G   A 1 3 ? 3.87748  14.11480 9.36248  0.478 6.87151  ? 3   G   A C5     1
+ATOM   157 C  C6     A G   A 1 3 ? 2.76946  14.48032 9.34248  0.522 7.53780  ? 3   G   A C6     1
+ATOM   158 C  C6     B G   A 1 3 ? 2.49304  14.43928 9.24774  0.478 7.23174  ? 3   G   A C6     1
+ATOM   159 O  O6     A G   A 1 3 ? 2.18251  15.57577 9.25144  0.522 7.21122  ? 3   G   A O6     1
+ATOM   160 O  O6     B G   A 1 3 ? 1.94393  15.56178 9.15646  0.478 9.19160  ? 3   G   A O6     1
+ATOM   161 N  N1     A G   A 1 3 ? 2.02312  13.31472 9.32171  0.522 7.59764  ? 3   G   A N1     1
+ATOM   162 N  N1     B G   A 1 3 ? 1.70009  13.30236 9.30110  0.478 7.19876  ? 3   G   A N1     1
+ATOM   163 C  C2     A G   A 1 3 ? 2.51987  12.05071 9.45840  0.522 8.19259  ? 3   G   A C2     1
+ATOM   164 C  C2     B G   A 1 3 ? 2.17800  12.02102 9.44532  0.478 7.65262  ? 3   G   A C2     1
+ATOM   165 N  N2     A G   A 1 3 ? 1.63210  11.06174 9.37773  0.522 8.13839  ? 3   G   A N2     1
+ATOM   166 N  N2     B G   A 1 3 ? 1.26398  11.03661 9.44775  0.478 8.13426  ? 3   G   A N2     1
+ATOM   167 N  N3     A G   A 1 3 ? 3.79415  11.78723 9.61989  0.522 7.92764  ? 3   G   A N3     1
+ATOM   168 N  N3     B G   A 1 3 ? 3.46239  11.72365 9.54970  0.478 8.26692  ? 3   G   A N3     1
+ATOM   169 C  C4     A G   A 1 3 ? 4.54303  12.89714 9.64438  0.522 8.39649  ? 3   G   A C4     1
+ATOM   170 C  C4     B G   A 1 3 ? 4.26051  12.80261 9.50119  0.478 7.90841  ? 3   G   A C4     1
+ATOM   171 H  "H5'"  A G   A 1 3 ? 9.56514  12.70301 7.13917  0.522 13.02410 ? 3   G   A "H5'"  1
+ATOM   172 H  "H5'"  B G   A 1 3 ? 9.55126  12.56732 7.13229  0.478 18.58376 ? 3   G   A "H5'"  1
+ATOM   173 H  "H5''" A G   A 1 3 ? 8.58849  13.67626 7.90949  0.522 13.02410 ? 3   G   A "H5''" 1
+ATOM   174 H  "H5''" B G   A 1 3 ? 8.87658  13.60512 8.11322  0.478 18.58376 ? 3   G   A "H5''" 1
+ATOM   175 H  "H4'"  A G   A 1 3 ? 9.33854  11.15517 8.95918  0.522 11.63767 ? 3   G   A "H4'"  1
+ATOM   176 H  "H4'"  B G   A 1 3 ? 9.12748  10.94258 8.93381  0.478 16.98369 ? 3   G   A "H4'"  1
+ATOM   177 H  "H3'"  A G   A 1 3 ? 7.03593  11.88569 7.47452  0.522 10.48115 ? 3   G   A "H3'"  1
+ATOM   178 H  "H3'"  B G   A 1 3 ? 7.03302  11.91264 7.28851  0.478 17.82500 ? 3   G   A "H3'"  1
+ATOM   179 H  "H2'"  A G   A 1 3 ? 5.68702  10.58644 8.73921  0.522 11.08247 ? 3   G   A "H2'"  1
+ATOM   180 H  "H2'"  B G   A 1 3 ? 5.56915  10.51254 8.37313  0.478 17.78534 ? 3   G   A "H2'"  1
+ATOM   181 H  "HO2'" A G   A 1 3 ? 7.44512  9.64574  10.34517 0.522 13.07142 ? 3   G   A "HO2'" 1
+ATOM   182 H  "HO2'" B G   A 1 3 ? 7.08930  8.85996  8.70433  0.478 18.41262 ? 3   G   A "HO2'" 1
+ATOM   183 H  "H1'"  A G   A 1 3 ? 6.56287  11.43002 10.94325 0.522 9.92364  ? 3   G   A "H1'"  1
+ATOM   184 H  "H1'"  B G   A 1 3 ? 6.30246  11.28424 10.67718 0.478 14.44011 ? 3   G   A "H1'"  1
+ATOM   185 H  H8     A G   A 1 3 ? 7.13640  14.56831 9.89598  0.522 12.20227 ? 3   G   A H8     1
+ATOM   186 H  H8     B G   A 1 3 ? 6.89135  14.42911 9.55691  0.478 9.30947  ? 3   G   A H8     1
+ATOM   187 H  H1     A G   A 1 3 ? 1.17363  13.39370 9.21341  0.522 9.12353  ? 3   G   A H1     1
+ATOM   188 H  H1     B G   A 1 3 ? 0.84861  13.40628 9.23959  0.478 8.64487  ? 3   G   A H1     1
+ATOM   189 H  H21    A G   A 1 3 ? 0.79760  11.24060 9.27180  0.522 9.77243  ? 3   G   A H21    1
+ATOM   190 H  H21    B G   A 1 3 ? 0.42784  11.22602 9.38006  0.478 9.76748  ? 3   G   A H21    1
+ATOM   191 H  H22    A G   A 1 3 ? 1.89317  10.24410 9.43155  0.522 9.77243  ? 3   G   A H22    1
+ATOM   192 H  H22    B G   A 1 3 ? 1.51497  10.21697 9.51700  0.478 9.76748  ? 3   G   A H22    1
+ATOM   193 P  P      A U   A 1 4 ? 7.29121  10.15981 5.60617  0.522 8.21587  ? 4   U   A P      1
+ATOM   194 P  P      B U   A 1 4 ? 7.33928  10.26601 5.33025  0.478 16.61610 ? 4   U   A P      1
+ATOM   195 O  OP1    A U   A 1 4 ? 7.99159  9.03224  4.95062  0.522 9.28169  ? 4   U   A OP1    1
+ATOM   196 O  OP1    B U   A 1 4 ? 8.20227  9.33312  4.58659  0.478 16.26048 ? 4   U   A OP1    1
+ATOM   197 O  OP2    A U   A 1 4 ? 7.21366  11.50564 4.99026  0.522 9.46847  ? 4   U   A OP2    1
+ATOM   198 O  OP2    B U   A 1 4 ? 7.18724  11.67042 4.86851  0.478 16.61353 ? 4   U   A OP2    1
+ATOM   199 O  "O5'"  A U   A 1 4 ? 5.79247  9.71838  5.90576  0.522 8.81962  ? 4   U   A "O5'"  1
+ATOM   200 O  "O5'"  B U   A 1 4 ? 5.87885  9.64343  5.47017  0.478 13.68652 ? 4   U   A "O5'"  1
+ATOM   201 C  "C5'"  A U   A 1 4 ? 5.48137  8.44539  6.46053  0.522 9.89736  ? 4   U   A "C5'"  1
+ATOM   202 C  "C5'"  B U   A 1 4 ? 5.64794  8.39998  6.12392  0.478 13.41296 ? 4   U   A "C5'"  1
+ATOM   203 C  "C4'"  A U   A 1 4 ? 4.00094  8.17521  6.36568  0.522 9.23990  ? 4   U   A "C4'"  1
+ATOM   204 C  "C4'"  B U   A 1 4 ? 4.17618  8.07665  6.16371  0.478 13.83250 ? 4   U   A "C4'"  1
+ATOM   205 O  "O4'"  A U   A 1 4 ? 3.26683  9.16900  7.12018  0.522 8.02777  ? 4   U   A "O4'"  1
+ATOM   206 O  "O4'"  B U   A 1 4 ? 3.48214  9.03645  6.99924  0.478 13.14097 ? 4   U   A "O4'"  1
+ATOM   207 C  "C3'"  A U   A 1 4 ? 3.41863  8.26627  4.97033  0.522 7.66792  ? 4   U   A "C3'"  1
+ATOM   208 C  "C3'"  B U   A 1 4 ? 3.45961  8.16603  4.83042  0.478 14.13616 ? 4   U   A "C3'"  1
+ATOM   209 O  "O3'"  A U   A 1 4 ? 3.62685  7.04991  4.28748  0.522 8.23975  ? 4   U   A "O3'"  1
+ATOM   210 O  "O3'"  B U   A 1 4 ? 3.62683  6.99924  4.05694  0.478 15.59917 ? 4   U   A "O3'"  1
+ATOM   211 C  "C2'"  A U   A 1 4 ? 1.95248  8.58851  5.23926  0.522 7.10323  ? 4   U   A "C2'"  1
+ATOM   212 C  "C2'"  B U   A 1 4 ? 2.01759  8.42381  5.23836  0.478 12.85662 ? 4   U   A "C2'"  1
+ATOM   213 O  "O2'"  A U   A 1 4 ? 1.22830  7.41770  5.59746  0.522 10.18945 ? 4   U   A "O2'"  1
+ATOM   214 O  "O2'"  B U   A 1 4 ? 1.38534  7.22395  5.65281  0.478 13.11949 ? 4   U   A "O2'"  1
+ATOM   215 C  "C1'"  A U   A 1 4 ? 2.06643  9.49392  6.45030  0.522 7.16506  ? 4   U   A "C1'"  1
+ATOM   216 C  "C1'"  B U   A 1 4 ? 2.20872  9.31799  6.45218  0.478 11.93701 ? 4   U   A "C1'"  1
+ATOM   217 N  N1     A U   A 1 4 ? 2.05287  10.95379 6.17732  0.522 7.95482  ? 4   U   A N1     1
+ATOM   218 N  N1     B U   A 1 4 ? 2.13345  10.76436 6.15518  0.478 11.08429 ? 4   U   A N1     1
+ATOM   219 C  C2     A U   A 1 4 ? 0.81342  11.56745 6.04390  0.522 7.17403  ? 4   U   A C2     1
+ATOM   220 C  C2     B U   A 1 4 ? 0.88682  11.34689 6.04014  0.478 12.21619 ? 4   U   A C2     1
+ATOM   221 O  O2     A U   A 1 4 ? -0.23555 10.93816 6.02949  0.522 8.27114  ? 4   U   A O2     1
+ATOM   222 O  O2     B U   A 1 4 ? -0.14364 10.69999 6.09266  0.478 12.31958 ? 4   U   A O2     1
+ATOM   223 N  N3     A U   A 1 4 ? 0.85594  12.94617 5.93354  0.522 5.65154  ? 4   U   A N3     1
+ATOM   224 N  N3     B U   A 1 4 ? 0.89746  12.71093 5.85092  0.478 12.69938 ? 4   U   A N3     1
+ATOM   225 C  C4     A U   A 1 4 ? 1.98503  13.73358 5.91111  0.522 6.64460  ? 4   U   A C4     1
+ATOM   226 C  C4     B U   A 1 4 ? 2.00486  13.53152 5.76229  0.478 11.16008 ? 4   U   A C4     1
+ATOM   227 O  O4     A U   A 1 4 ? 1.86976  14.95190 5.80529  0.522 6.10866  ? 4   U   A O4     1
+ATOM   228 O  O4     B U   A 1 4 ? 1.85346  14.74612 5.59020  0.478 12.88795 ? 4   U   A O4     1
+ATOM   229 C  C5     A U   A 1 4 ? 3.21274  13.03681 6.04239  0.522 7.56377  ? 4   U   A C5     1
+ATOM   230 C  C5     B U   A 1 4 ? 3.25457  12.85765 5.90438  0.478 10.93613 ? 4   U   A C5     1
+ATOM   231 C  C6     A U   A 1 4 ? 3.21521  11.70786 6.20481  0.522 8.71824  ? 4   U   A C6     1
+ATOM   232 C  C6     B U   A 1 4 ? 3.27729  11.53298 6.09839  0.478 11.04949 ? 4   U   A C6     1
+ATOM   233 H  "H5'"  A U   A 1 4 ? 5.75218  8.42618  7.39176  0.522 11.88319 ? 4   U   A "H5'"  1
+ATOM   234 H  "H5'"  B U   A 1 4 ? 5.98881  8.44802  7.03079  0.478 16.10192 ? 4   U   A "H5'"  1
+ATOM   235 H  "H5''" A U   A 1 4 ? 5.96487  7.75756  5.97678  0.522 11.88319 ? 4   U   A "H5''" 1
+ATOM   236 H  "H5''" B U   A 1 4 ? 6.11642  7.69695  5.64729  0.478 16.10192 ? 4   U   A "H5''" 1
+ATOM   237 H  "H4'"  A U   A 1 4 ? 3.80813  7.30185  6.74115  0.522 11.09425 ? 4   U   A "H4'"  1
+ATOM   238 H  "H4'"  B U   A 1 4 ? 4.05134  7.19160  6.54055  0.478 16.60536 ? 4   U   A "H4'"  1
+ATOM   239 H  "H3'"  A U   A 1 4 ? 3.79679  9.00906  4.47418  0.522 9.20786  ? 4   U   A "H3'"  1
+ATOM   240 H  "H3'"  B U   A 1 4 ? 3.78671  8.93519  4.33817  0.478 16.96975 ? 4   U   A "H3'"  1
+ATOM   241 H  "H2'"  A U   A 1 4 ? 1.53720  9.04403  4.49030  0.522 8.53024  ? 4   U   A "H2'"  1
+ATOM   242 H  "H2'"  B U   A 1 4 ? 1.51648  8.86830  4.53677  0.478 15.43430 ? 4   U   A "H2'"  1
+ATOM   243 H  "HO2'" A U   A 1 4 ? 1.23182  7.33911  6.43377  0.522 12.23370 ? 4   U   A "HO2'" 1
+ATOM   244 H  "HO2'" B U   A 1 4 ? 1.26562  6.73222  4.98238  0.478 15.74975 ? 4   U   A "HO2'" 1
+ATOM   245 H  "H1'"  A U   A 1 4 ? 1.29754  9.30769  7.01157  0.522 8.60444  ? 4   U   A "H1'"  1
+ATOM   246 H  "H1'"  B U   A 1 4 ? 1.51415  9.10465  7.09481  0.478 14.33077 ? 4   U   A "H1'"  1
+ATOM   247 H  H3     A U   A 1 4 ? 0.10036  13.35238 5.87279  0.522 6.78821  ? 4   U   A H3     1
+ATOM   248 H  H3     B U   A 1 4 ? 0.13059  13.09370 5.78020  0.478 15.24562 ? 4   U   A H3     1
+ATOM   249 H  H5     A U   A 1 4 ? 4.01690  13.50319 6.01566  0.522 9.08289  ? 4   U   A H5     1
+ATOM   250 H  H5     B U   A 1 4 ? 4.05052  13.33682 5.86238  0.478 13.12972 ? 4   U   A H5     1
+ATOM   251 H  H6     A U   A 1 4 ? 4.02688  11.27483 6.34110  0.522 10.46825 ? 4   U   A H6     1
+ATOM   252 H  H6     B U   A 1 4 ? 4.10070  11.11262 6.19930  0.478 13.26574 ? 4   U   A H6     1
+ATOM   253 P  P      A G   A 1 5 ? 4.11698  6.99705  2.75761  0.522 7.68574  ? 5   G   A P      1
+ATOM   254 P  P      B G   A 1 5 ? 4.12230  7.10908  2.54096  0.478 15.97494 ? 5   G   A P      1
+ATOM   255 O  OP1    A G   A 1 5 ? 4.71562  5.64760  2.53811  0.522 8.26056  ? 5   G   A OP1    1
+ATOM   256 O  OP1    B G   A 1 5 ? 4.77144  5.82978  2.16584  0.478 16.91049 ? 5   G   A OP1    1
+ATOM   257 O  OP2    A G   A 1 5 ? 4.95587  8.18852  2.44573  0.522 8.36661  ? 5   G   A OP2    1
+ATOM   258 O  OP2    B G   A 1 5 ? 4.90569  8.35812  2.38869  0.478 15.42355 ? 5   G   A OP2    1
+ATOM   259 O  "O5'"  A G   A 1 5 ? 2.77255  7.13509  1.92737  0.522 7.95615  ? 5   G   A "O5'"  1
+ATOM   260 O  "O5'"  B G   A 1 5 ? 2.78642  7.23440  1.68973  0.478 14.04246 ? 5   G   A "O5'"  1
+ATOM   261 C  "C5'"  A G   A 1 5 ? 1.86185  6.04902  1.87700  0.522 8.66784  ? 5   G   A "C5'"  1
+ATOM   262 C  "C5'"  B G   A 1 5 ? 1.92590  6.12020  1.53451  0.478 14.57761 ? 5   G   A "C5'"  1
+ATOM   263 C  "C4'"  A G   A 1 5 ? 0.55879  6.50020  1.29241  0.522 8.50579  ? 5   G   A "C4'"  1
+ATOM   264 C  "C4'"  B G   A 1 5 ? 0.52253  6.56791  1.24490  0.478 13.11365 ? 5   G   A "C4'"  1
+ATOM   265 O  "O4'"  A G   A 1 5 ? -0.09191 7.39379  2.22733  0.522 8.54745  ? 5   G   A "O4'"  1
+ATOM   266 O  "O4'"  B G   A 1 5 ? 0.05204  7.41368  2.32415  0.478 10.84418 ? 5   G   A "O4'"  1
+ATOM   267 C  "C3'"  A G   A 1 5 ? 0.65670  7.31066  0.01347  0.522 8.18204  ? 5   G   A "C3'"  1
+ATOM   268 C  "C3'"  B G   A 1 5 ? 0.33468  7.42856  0.00907  0.478 14.52493 ? 5   G   A "C3'"  1
+ATOM   269 O  "O3'"  A G   A 1 5 ? 0.79478  6.48396  -1.12193 0.522 7.94409  ? 5   G   A "O3'"  1
+ATOM   270 O  "O3'"  B G   A 1 5 ? 0.32926  6.67718  -1.18794 0.478 15.78470 ? 5   G   A "O3'"  1
+ATOM   271 C  "C2'"  A G   A 1 5 ? -0.63542 8.11363  0.03316  0.522 8.01225  ? 5   G   A "C2'"  1
+ATOM   272 C  "C2'"  B G   A 1 5 ? -0.97769 8.13811  0.30854  0.478 13.68197 ? 5   G   A "C2'"  1
+ATOM   273 O  "O2'"  A G   A 1 5 ? -1.73210 7.31144  -0.38510 0.522 7.90735  ? 5   G   A "O2'"  1
+ATOM   274 O  "O2'"  B G   A 1 5 ? -2.08801 7.27915  0.09055  0.478 15.81144 ? 5   G   A "O2'"  1
+ATOM   275 C  "C1'"  A G   A 1 5 ? -0.76813 8.41584  1.52615  0.522 8.11000  ? 5   G   A "C1'"  1
+ATOM   276 C  "C1'"  B G   A 1 5 ? -0.83767 8.38870  1.81123  0.478 11.11510 ? 5   G   A "C1'"  1
+ATOM   277 N  N9     A G   A 1 5 ? -0.14540 9.70201  1.89507  0.522 8.64396  ? 5   G   A N9     1
+ATOM   278 N  N9     B G   A 1 5 ? -0.27546 9.71984  2.09324  0.478 7.57498  ? 5   G   A N9     1
+ATOM   279 C  C8     A G   A 1 5 ? 1.18783  9.98782  2.06464  0.522 9.03418  ? 5   G   A C8     1
+ATOM   280 C  C8     B G   A 1 5 ? 1.04841  10.04944 2.24121  0.478 8.02024  ? 5   G   A C8     1
+ATOM   281 N  N7     A G   A 1 5 ? 1.40844  11.22886 2.39800  0.522 10.33572 ? 5   G   A N7     1
+ATOM   282 N  N7     B G   A 1 5 ? 1.23755  11.31457 2.50395  0.478 7.47077  ? 5   G   A N7     1
+ATOM   283 C  C5     A G   A 1 5 ? 0.14879  11.80112 2.43522  0.522 10.17539 ? 5   G   A C5     1
+ATOM   284 C  C5     B G   A 1 5 ? -0.04299 11.86248 2.50100  0.478 6.48422  ? 5   G   A C5     1
+ATOM   285 C  C6     A G   A 1 5 ? -0.24077 13.13151 2.70431  0.522 9.20400  ? 5   G   A C6     1
+ATOM   286 C  C6     B G   A 1 5 ? -0.47313 13.19467 2.68490  0.478 5.97700  ? 5   G   A C6     1
+ATOM   287 O  O6     A G   A 1 5 ? 0.46885  14.10811 2.98663  0.522 9.73792  ? 5   G   A O6     1
+ATOM   288 O  O6     B G   A 1 5 ? 0.21206  14.20828 2.88957  0.478 5.40476  ? 5   G   A O6     1
+ATOM   289 N  N1     A G   A 1 5 ? -1.62149 13.26339 2.63322  0.522 8.83487  ? 5   G   A N1     1
+ATOM   290 N  N1     B G   A 1 5 ? -1.85776 13.27850 2.61097  0.478 7.22144  ? 5   G   A N1     1
+ATOM   291 C  C2     A G   A 1 5 ? -2.49876 12.24756 2.31391  0.522 9.86057  ? 5   G   A C2     1
+ATOM   292 C  C2     B G   A 1 5 ? -2.71564 12.22286 2.35845  0.478 7.57922  ? 5   G   A C2     1
+ATOM   293 N  N2     A G   A 1 5 ? -3.79621 12.54434 2.26750  0.522 9.86774  ? 5   G   A N2     1
+ATOM   294 N  N2     B G   A 1 5 ? -4.02275 12.51422 2.29881  0.478 8.51457  ? 5   G   A N2     1
+ATOM   295 N  N3     A G   A 1 5 ? -2.14352 11.00757 2.04208  0.522 9.96843  ? 5   G   A N3     1
+ATOM   296 N  N3     B G   A 1 5 ? -2.32446 10.97539 2.16572  0.478 8.04657  ? 5   G   A N3     1
+ATOM   297 C  C4     A G   A 1 5 ? -0.80968 10.87312 2.11349  0.522 9.35575  ? 5   G   A C4     1
+ATOM   298 C  C4     B G   A 1 5 ? -0.97956 10.88371 2.24909  0.478 7.62449  ? 5   G   A C4     1
+ATOM   299 H  "H5'"  A G   A 1 5 ? 1.71357  5.70981  2.77358  0.522 10.40777 ? 5   G   A "H5'"  1
+ATOM   300 H  "H5'"  B G   A 1 5 ? 1.93235  5.59483  2.34989  0.478 17.49949 ? 5   G   A "H5'"  1
+ATOM   301 H  "H5''" A G   A 1 5 ? 2.23388  5.34052  1.32881  0.522 10.40777 ? 5   G   A "H5''" 1
+ATOM   302 H  "H5''" B G   A 1 5 ? 2.24389  5.56990  0.80174  0.478 17.49949 ? 5   G   A "H5''" 1
+ATOM   303 H  "H4'"  A G   A 1 5 ? -0.01059 5.73138  1.13232  0.522 10.21331 ? 5   G   A "H4'"  1
+ATOM   304 H  "H4'"  B G   A 1 5 ? -0.04731 5.78619  1.17356  0.478 15.74274 ? 5   G   A "H4'"  1
+ATOM   305 H  "H3'"  A G   A 1 5 ? 1.40605  7.92442  0.06515  0.522 9.82481  ? 5   G   A "H3'"  1
+ATOM   306 H  "H3'"  B G   A 1 5 ? 1.04442  8.08785  -0.04104 0.478 17.43628 ? 5   G   A "H3'"  1
+ATOM   307 H  "H2'"  A G   A 1 5 ? -0.57383 8.92779  -0.49052 0.522 9.62106  ? 5   G   A "H2'"  1
+ATOM   308 H  "H2'"  B G   A 1 5 ? -1.06548 8.96399  -0.19258 0.478 16.42473 ? 5   G   A "H2'"  1
+ATOM   309 H  "HO2'" A G   A 1 5 ? -2.17596 7.08158  0.28999  0.522 9.49519  ? 5   G   A "HO2'" 1
+ATOM   310 H  "HO2'" B G   A 1 5 ? -2.15250 7.11883  -0.73148 0.478 18.98008 ? 5   G   A "HO2'" 1
+ATOM   311 H  "H1'"  A G   A 1 5 ? -1.70760 8.42438  1.76743  0.522 9.73836  ? 5   G   A "H1'"  1
+ATOM   312 H  "H1'"  B G   A 1 5 ? -1.70344 8.29984  2.23952  0.478 13.34448 ? 5   G   A "H1'"  1
+ATOM   313 H  H8     A G   A 1 5 ? 1.86441  9.35961  1.95293  0.522 10.84738 ? 5   G   A H8     1
+ATOM   314 H  H8     B G   A 1 5 ? 1.74107  9.43390  2.16232  0.478 9.63065  ? 5   G   A H8     1
+ATOM   315 H  H1     A G   A 1 5 ? -1.95536 14.03794 2.80117  0.522 10.60820 ? 5   G   A H1     1
+ATOM   316 H  H1     B G   A 1 5 ? -2.21194 14.05269 2.73255  0.478 8.67209  ? 5   G   A H1     1
+ATOM   317 H  H21    A G   A 1 5 ? -4.06075 13.34434 2.43962  0.522 11.84764 ? 5   G   A H21    1
+ATOM   318 H  H21    B G   A 1 5 ? -4.28922 13.32248 2.42256  0.478 10.22384 ? 5   G   A H21    1
+ATOM   319 H  H22    A G   A 1 5 ? -4.36951 11.93599 2.06541  0.522 11.84764 ? 5   G   A H22    1
+ATOM   320 H  H22    B G   A 1 5 ? -4.59485 11.89289 2.13679  0.478 10.22384 ? 5   G   A H22    1
+ATOM   321 P  P      A U   A 1 6 ? 1.44587  7.02684  -2.48687 0.522 8.85408  ? 6   U   A P      1
+ATOM   322 P  P      B U   A 1 6 ? 1.04682  7.24388  -2.50913 0.478 18.20812 ? 6   U   A P      1
+ATOM   323 O  OP1    A U   A 1 6 ? 0.71586  8.26533  -2.90223 0.522 10.85690 ? 6   U   A OP1    1
+ATOM   324 O  OP1    B U   A 1 6 ? 0.49090  8.58722  -2.81181 0.478 18.42998 ? 6   U   A OP1    1
+ATOM   325 O  OP2    A U   A 1 6 ? 1.49002  5.86530  -3.38612 0.522 10.48147 ? 6   U   A OP2    1
+ATOM   326 O  OP2    B U   A 1 6 ? 1.00223  6.17368  -3.52801 0.478 17.66124 ? 6   U   A OP2    1
+ATOM   327 O  "O5'"  A U   A 1 6 ? 2.94546  7.38470  -2.05513 0.522 9.20115  ? 6   U   A "O5'"  1
+ATOM   328 O  "O5'"  B U   A 1 6 ? 2.56515  7.47222  -2.07919 0.478 17.36115 ? 6   U   A "O5'"  1
+ATOM   329 C  "C5'"  A U   A 1 6 ? 3.95580  7.64993  -3.03212 0.522 8.57138  ? 6   U   A "C5'"  1
+ATOM   330 C  "C5'"  B U   A 1 6 ? 3.56419  7.69688  -3.07294 0.478 15.70738 ? 6   U   A "C5'"  1
+ATOM   331 C  "C4'"  A U   A 1 6 ? 4.90143  8.74813  -2.59749 0.522 9.27986  ? 6   U   A "C4'"  1
+ATOM   332 C  "C4'"  B U   A 1 6 ? 4.52602  8.80448  -2.70519 0.478 12.01112 ? 6   U   A "C4'"  1
+ATOM   333 O  "O4'"  A U   A 1 6 ? 4.22407  10.03717 -2.67487 0.522 10.66772 ? 6   U   A "O4'"  1
+ATOM   334 O  "O4'"  B U   A 1 6 ? 3.84545  10.09145 -2.77632 0.478 10.71658 ? 6   U   A "O4'"  1
+ATOM   335 C  "C3'"  A U   A 1 6 ? 5.43813  8.63068  -1.16792 0.522 9.17667  ? 6   U   A "C3'"  1
+ATOM   336 C  "C3'"  B U   A 1 6 ? 5.15071  8.72801  -1.30903 0.478 12.73613 ? 6   U   A "C3'"  1
+ATOM   337 O  "O3'"  A U   A 1 6 ? 6.78556  9.10266  -1.08075 0.522 9.81541  ? 6   U   A "O3'"  1
+ATOM   338 O  "O3'"  B U   A 1 6 ? 6.50967  9.16801  -1.35173 0.478 12.84501 ? 6   U   A "O3'"  1
+ATOM   339 C  "C2'"  A U   A 1 6 ? 4.54541  9.59839  -0.41088 0.522 9.49548  ? 6   U   A "C2'"  1
+ATOM   340 C  "C2'"  B U   A 1 6 ? 4.32945  9.74278  -0.52426 0.478 10.25907 ? 6   U   A "C2'"  1
+ATOM   341 O  "O2'"  A U   A 1 6 ? 5.09045  10.07369 0.80187  0.522 10.16201 ? 6   U   A "O2'"  1
+ATOM   342 O  "O2'"  B U   A 1 6 ? 4.97456  10.27136 0.61379  0.478 10.08033 ? 6   U   A "O2'"  1
+ATOM   343 C  "C1'"  A U   A 1 6 ? 4.37927  10.70814 -1.44643 0.522 9.41873  ? 6   U   A "C1'"  1
+ATOM   344 C  "C1'"  B U   A 1 6 ? 4.09254  10.80998 -1.58973 0.478 10.76312 ? 6   U   A "C1'"  1
+ATOM   345 N  N1     A U   A 1 6 ? 3.22075  11.56509 -1.19706 0.522 8.40174  ? 6   U   A N1     1
+ATOM   346 N  N1     B U   A 1 6 ? 2.96414  11.70029 -1.30503 0.478 9.94280  ? 6   U   A N1     1
+ATOM   347 C  C2     A U   A 1 6 ? 3.47309  12.86951 -0.84255 0.522 8.48535  ? 6   U   A C2     1
+ATOM   348 C  C2     B U   A 1 6 ? 3.24475  13.02518 -1.03278 0.478 9.24749  ? 6   U   A C2     1
+ATOM   349 O  O2     A U   A 1 6 ? 4.59453  13.33840 -0.78187 0.522 9.69738  ? 6   U   A O2     1
+ATOM   350 O  O2     B U   A 1 6 ? 4.37489  13.49051 -1.05921 0.478 9.09509  ? 6   U   A O2     1
+ATOM   351 N  N3     A U   A 1 6 ? 2.34317  13.60962 -0.55217 0.522 8.36460  ? 6   U   A N3     1
+ATOM   352 N  N3     B U   A 1 6 ? 2.13047  13.78089 -0.72958 0.478 8.47325  ? 6   U   A N3     1
+ATOM   353 C  C4     A U   A 1 6 ? 1.03435  13.17441 -0.58510 0.522 7.40166  ? 6   U   A C4     1
+ATOM   354 C  C4     B U   A 1 6 ? 0.81825  13.34838 -0.67004 0.478 9.75348  ? 6   U   A C4     1
+ATOM   355 O  O4     A U   A 1 6 ? 0.14315  13.98159 -0.27816 0.522 7.56356  ? 6   U   A O4     1
+ATOM   356 O  O4     B U   A 1 6 ? -0.06741 14.15557 -0.37361 0.478 9.85519  ? 6   U   A O4     1
+ATOM   357 C  C5     A U   A 1 6 ? 0.86204  11.79932 -0.96146 0.522 8.82480  ? 6   U   A C5     1
+ATOM   358 C  C5     B U   A 1 6 ? 0.61944  11.96438 -0.96814 0.478 10.14866 ? 6   U   A C5     1
+ATOM   359 C  C6     A U   A 1 6 ? 1.94525  11.05554 -1.23903 0.522 8.87722  ? 6   U   A C6     1
+ATOM   360 C  C6     B U   A 1 6 ? 1.68160  11.20406 -1.26125 0.478 11.11060 ? 6   U   A C6     1
+ATOM   361 H  "H5'"  A U   A 1 6 ? 3.52823  7.91430  -3.86170 0.522 10.29202 ? 6   U   A "H5'"  1
+ATOM   362 H  "H5'"  B U   A 1 6 ? 3.12641  7.92954  -3.90668 0.478 18.85521 ? 6   U   A "H5'"  1
+ATOM   363 H  "H5''" A U   A 1 6 ? 4.46572  6.83890  -3.18414 0.522 10.29202 ? 6   U   A "H5''" 1
+ATOM   364 H  "H5''" B U   A 1 6 ? 4.06747  6.87722  -3.19852 0.478 18.85521 ? 6   U   A "H5''" 1
+ATOM   365 H  "H4'"  A U   A 1 6 ? 5.65354  8.76099  -3.20992 0.522 11.14220 ? 6   U   A "H4'"  1
+ATOM   366 H  "H4'"  B U   A 1 6 ? 5.24421  8.79738  -3.35715 0.478 14.41971 ? 6   U   A "H4'"  1
+ATOM   367 H  "H3'"  A U   A 1 6 ? 5.36582  7.71566  -0.85423 0.522 11.01836 ? 6   U   A "H3'"  1
+ATOM   368 H  "H3'"  B U   A 1 6 ? 5.07766  7.83214  -0.94435 0.478 15.28971 ? 6   U   A "H3'"  1
+ATOM   369 H  "H2'"  A U   A 1 6 ? 3.68441  9.18883  -0.23248 0.522 11.40093 ? 6   U   A "H2'"  1
+ATOM   370 H  "H2'"  B U   A 1 6 ? 3.48466  9.34716  -0.25836 0.478 12.31724 ? 6   U   A "H2'"  1
+ATOM   371 H  "H1'"  A U   A 1 6 ? 5.17240  11.26463 -1.49300 0.522 11.30884 ? 6   U   A "H1'"  1
+ATOM   372 H  "H1'"  B U   A 1 6 ? 4.88650  11.35439 -1.70863 0.478 12.92210 ? 6   U   A "H1'"  1
+ATOM   373 H  H3     A U   A 1 6 ? 2.46923  14.42988 -0.32662 0.522 10.04389 ? 6   U   A H3     1
+ATOM   374 H  H3     B U   A 1 6 ? 2.26723  14.61260 -0.55882 0.478 10.17426 ? 6   U   A H3     1
+ATOM   375 H  H5     A U   A 1 6 ? 0.01074  11.42838 -1.01236 0.522 10.59612 ? 6   U   A H5     1
+ATOM   376 H  H5     B U   A 1 6 ? -0.23516 11.59767 -0.95859 0.478 12.18475 ? 6   U   A H5     1
+ATOM   377 H  H6     A U   A 1 6 ? 1.82770  10.16194 -1.46829 0.522 10.65903 ? 6   U   A H6     1
+ATOM   378 H  H6     B U   A 1 6 ? 1.54682  10.30201 -1.44303 0.478 13.33908 ? 6   U   A H6     1
+ATOM   379 O  "O5'"  A G   B 1 1 ? 8.12027  13.64373 15.74638 0.484 16.67711 ? 1   G   B "O5'"  1
+ATOM   380 O  "O5'"  B G   B 1 1 ? 8.09852  13.80131 16.08429 0.516 11.07380 ? 1   G   B "O5'"  1
+ATOM   381 C  "C5'"  A G   B 1 1 ? 8.66478  12.86954 16.81007 0.484 14.75132 ? 1   G   B "C5'"  1
+ATOM   382 C  "C5'"  B G   B 1 1 ? 8.68002  12.84887 16.96893 0.516 11.33068 ? 1   G   B "C5'"  1
+ATOM   383 C  "C4'"  A G   B 1 1 ? 8.12872  11.45883 16.82425 0.484 13.19930 ? 1   G   B "C4'"  1
+ATOM   384 C  "C4'"  B G   B 1 1 ? 8.24881  11.43729 16.65484 0.516 9.99177  ? 1   G   B "C4'"  1
+ATOM   385 O  "O4'"  A G   B 1 1 ? 6.72338  11.49631 17.19882 0.484 11.40013 ? 1   G   B "O4'"  1
+ATOM   386 O  "O4'"  B G   B 1 1 ? 6.84873  11.29444 17.00214 0.516 9.70196  ? 1   G   B "O4'"  1
+ATOM   387 C  "C3'"  A G   B 1 1 ? 8.19668  10.72334 15.48207 0.484 13.17715 ? 1   G   B "C3'"  1
+ATOM   388 C  "C3'"  B G   B 1 1 ? 8.35659  11.05122 15.18590 0.516 10.91076 ? 1   G   B "C3'"  1
+ATOM   389 O  "O3'"  A G   B 1 1 ? 8.43669  9.32518  15.67819 0.484 15.46493 ? 1   G   B "O3'"  1
+ATOM   390 O  "O3'"  B G   B 1 1 ? 8.59254  9.65438  15.04820 0.516 12.34409 ? 1   G   B "O3'"  1
+ATOM   391 C  "C2'"  A G   B 1 1 ? 6.78553  10.91515 14.93223 0.484 12.68798 ? 1   G   B "C2'"  1
+ATOM   392 C  "C2'"  B G   B 1 1 ? 6.96756  11.36328 14.65994 0.516 10.01112 ? 1   G   B "C2'"  1
+ATOM   393 O  "O2'"  A G   B 1 1 ? 6.39734  9.94237  13.99025 0.484 13.49340 ? 1   G   B "O2'"  1
+ATOM   394 O  "O2'"  B G   B 1 1 ? 6.63645  10.65854 13.47547 0.516 11.71144 ? 1   G   B "O2'"  1
+ATOM   395 C  "C1'"  A G   B 1 1 ? 5.95704  10.83372 16.21522 0.484 11.54636 ? 1   G   B "C1'"  1
+ATOM   396 C  "C1'"  B G   B 1 1 ? 6.10982  10.94382 15.85098 0.516 9.13147  ? 1   G   B "C1'"  1
+ATOM   397 N  N9     A G   B 1 1 ? 4.62581  11.45467 16.15885 0.484 10.13446 ? 1   G   B N9     1
+ATOM   398 N  N9     B G   B 1 1 ? 4.81346  11.61371 15.91223 0.516 8.15691  ? 1   G   B N9     1
+ATOM   399 C  C8     A G   B 1 1 ? 3.41656  10.79641 16.15444 0.484 10.35474 ? 1   G   B C8     1
+ATOM   400 C  C8     B G   B 1 1 ? 3.60207  10.98129 15.91678 0.516 7.98034  ? 1   G   B C8     1
+ATOM   401 N  N7     A G   B 1 1 ? 2.37902  11.58958 16.10191 0.484 9.26393  ? 1   G   B N7     1
+ATOM   402 N  N7     B G   B 1 1 ? 2.59528  11.80653 15.94892 0.516 7.42955  ? 1   G   B N7     1
+ATOM   403 C  C5     A G   B 1 1 ? 2.93959  12.85336 16.07656 0.484 8.78346  ? 1   G   B C5     1
+ATOM   404 C  C5     B G   B 1 1 ? 3.19416  13.05497 15.98368 0.516 6.85698  ? 1   G   B C5     1
+ATOM   405 C  C6     A G   B 1 1 ? 2.30491  14.12340 16.02308 0.484 8.13327  ? 1   G   B C6     1
+ATOM   406 C  C6     B G   B 1 1 ? 2.59211  14.33504 16.03323 0.516 6.66954  ? 1   G   B C6     1
+ATOM   407 O  O6     A G   B 1 1 ? 1.10132  14.42183 15.96578 0.484 8.03975  ? 1   G   B O6     1
+ATOM   408 O  O6     B G   B 1 1 ? 1.38986  14.65243 16.04179 0.516 6.66534  ? 1   G   B O6     1
+ATOM   409 N  N1     A G   B 1 1 ? 3.23449  15.15345 16.00486 0.484 8.14313  ? 1   G   B N1     1
+ATOM   410 N  N1     B G   B 1 1 ? 3.55447  15.34028 16.01639 0.516 7.13817  ? 1   G   B N1     1
+ATOM   411 C  C2     A G   B 1 1 ? 4.59401  14.97999 16.05453 0.484 9.04019  ? 1   G   B C2     1
+ATOM   412 C  C2     B G   B 1 1 ? 4.90646  15.13484 15.99865 0.516 6.99784  ? 1   G   B C2     1
+ATOM   413 N  N2     A G   B 1 1 ? 5.33129  16.08769 16.02241 0.484 8.76843  ? 1   G   B N2     1
+ATOM   414 N  N2     B G   B 1 1 ? 5.65182  16.23712 16.00094 0.516 7.47533  ? 1   G   B N2     1
+ATOM   415 N  N3     A G   B 1 1 ? 5.19628  13.80164 16.10614 0.484 8.08566  ? 1   G   B N3     1
+ATOM   416 N  N3     B G   B 1 1 ? 5.48512  13.94623 15.95800 0.516 8.37503  ? 1   G   B N3     1
+ATOM   417 C  C4     A G   B 1 1 ? 4.31787  12.78861 16.11760 0.484 8.46928  ? 1   G   B C4     1
+ATOM   418 C  C4     B G   B 1 1 ? 4.56762  12.96018 15.96026 0.516 7.43239  ? 1   G   B C4     1
+ATOM   419 H  "H5'"  A G   B 1 1 ? 8.44607  13.29679 17.65300 0.484 17.70795 ? 1   G   B "H5'"  1
+ATOM   420 H  "H5'"  B G   B 1 1 ? 8.41617  13.06266 17.87754 0.516 13.60317 ? 1   G   B "H5'"  1
+ATOM   421 H  "H5''" A G   B 1 1 ? 9.62940  12.83768 16.71309 0.484 17.70795 ? 1   G   B "H5''" 1
+ATOM   422 H  "H5''" B G   B 1 1 ? 9.64590  12.90470 16.89914 0.516 13.60317 ? 1   G   B "H5''" 1
+ATOM   423 H  "H4'"  A G   B 1 1 ? 8.61529  10.94123 17.48474 0.484 15.84552 ? 1   G   B "H4'"  1
+ATOM   424 H  "H4'"  B G   B 1 1 ? 8.77224  10.81568 17.18448 0.516 11.99648 ? 1   G   B "H4'"  1
+ATOM   425 H  "H3'"  A G   B 1 1 ? 8.87507  11.11530 14.91018 0.484 15.81894 ? 1   G   B "H3'"  1
+ATOM   426 H  "H3'"  B G   B 1 1 ? 9.04782  11.57127 14.74699 0.516 13.09928 ? 1   G   B "H3'"  1
+ATOM   427 H  "H2'"  A G   B 1 1 ? 6.69444  11.79890 14.54290 0.484 15.23193 ? 1   G   B "H2'"  1
+ATOM   428 H  "H2'"  B G   B 1 1 ? 6.85964  12.31551 14.50992 0.516 12.01971 ? 1   G   B "H2'"  1
+ATOM   429 H  "HO2'" A G   B 1 1 ? 6.88989  10.00582 13.31278 0.484 16.19844 ? 1   G   B "HO2'" 1
+ATOM   430 H  "HO2'" B G   B 1 1 ? 7.12210  10.93463 12.84816 0.516 14.06009 ? 1   G   B "HO2'" 1
+ATOM   431 H  "H1'"  A G   B 1 1 ? 5.84174  9.90047  16.45320 0.484 13.86200 ? 1   G   B "H1'"  1
+ATOM   432 H  "H1'"  B G   B 1 1 ? 5.97742  9.98302  15.83528 0.516 10.96412 ? 1   G   B "H1'"  1
+ATOM   433 H  H8     A G   B 1 1 ? 3.34439  9.86975  16.18604 0.484 12.43205 ? 1   G   B H8     1
+ATOM   434 H  H8     B G   B 1 1 ? 3.50649  10.05639 15.89876 0.516 9.58277  ? 1   G   B H8     1
+ATOM   435 H  H1     A G   B 1 1 ? 2.93654  15.95889 15.95911 0.484 9.77812  ? 1   G   B H1     1
+ATOM   436 H  H1     B G   B 1 1 ? 3.27727  16.15438 16.01720 0.516 8.57216  ? 1   G   B H1     1
+ATOM   437 H  H21    A G   B 1 1 ? 4.94946  16.85755 15.98883 0.484 10.52847 ? 1   G   B H21    1
+ATOM   438 H  H21    B G   B 1 1 ? 5.27606  17.01023 16.02737 0.516 8.97676  ? 1   G   B H21    1
+ATOM   439 H  H22    A G   B 1 1 ? 6.18949  16.03355 16.03523 0.484 10.52847 ? 1   G   B H22    1
+ATOM   440 H  H22    B G   B 1 1 ? 6.50931  16.17642 15.97600 0.516 8.97676  ? 1   G   B H22    1
+ATOM   441 H  "HO5'" A G   B 1 1 ? 7.29834  13.81072 15.72321 0.484 20.01889 ? 1   G   B "HO5'" 1
+ATOM   442 H  "HO5'" B G   B 1 1 ? 7.26405  13.85341 16.01997 0.516 13.29492 ? 1   G   B "HO5'" 1
+ATOM   443 P  P      A U   B 1 2 ? 9.77464  8.61645  15.13114 0.484 19.83956 ? 2   U   B P      1
+ATOM   444 P  P      B U   B 1 2 ? 10.04083 9.18566  14.57319 0.516 14.45267 ? 2   U   B P      1
+ATOM   445 O  OP1    A U   B 1 2 ? 10.00032 9.05638  13.73441 0.484 23.01776 ? 2   U   B OP1    1
+ATOM   446 O  OP1    B U   B 1 2 ? 10.43757 9.93511  13.36233 0.516 16.70768 ? 2   U   B OP1    1
+ATOM   447 O  OP2    A U   B 1 2 ? 9.63407  7.17690  15.44473 0.484 22.15412 ? 2   U   B OP2    1
+ATOM   448 O  OP2    B U   B 1 2 ? 10.01937 7.70694  14.56206 0.516 15.35375 ? 2   U   B OP2    1
+ATOM   449 O  "O5'"  A U   B 1 2 ? 10.94442 9.25551  15.97967 0.484 23.38331 ? 2   U   B "O5'"  1
+ATOM   450 O  "O5'"  B U   B 1 2 ? 10.97426 9.71759  15.73162 0.516 14.99241 ? 2   U   B "O5'"  1
+ATOM   451 C  "C5'"  A U   B 1 2 ? 11.20729 8.79370  17.29128 0.484 25.68927 ? 2   U   B "C5'"  1
+ATOM   452 C  "C5'"  B U   B 1 2 ? 11.13256 9.00493  16.95078 0.516 15.22758 ? 2   U   B "C5'"  1
+ATOM   453 C  "C4'"  A U   B 1 2 ? 12.25554 9.63762  17.95941 0.484 28.54998 ? 2   U   B "C4'"  1
+ATOM   454 C  "C4'"  B U   B 1 2 ? 12.18702 9.66739  17.79103 0.516 14.89109 ? 2   U   B "C4'"  1
+ATOM   455 O  "O4'"  A U   B 1 2 ? 13.52262 9.48456  17.26432 0.484 31.86519 ? 2   U   B "O4'"  1
+ATOM   456 O  "O4'"  B U   B 1 2 ? 13.48662 9.48387  17.15110 0.516 15.79275 ? 2   U   B "O4'"  1
+ATOM   457 C  "C3'"  A U   B 1 2 ? 11.95689 11.13546 17.98472 0.484 28.58067 ? 2   U   B "C3'"  1
+ATOM   458 C  "C3'"  B U   B 1 2 ? 11.99571 11.17428 17.93506 0.516 15.30113 ? 2   U   B "C3'"  1
+ATOM   459 O  "O3'"  A U   B 1 2 ? 12.31849 11.67303 19.24476 0.484 23.92677 ? 2   U   B "O3'"  1
+ATOM   460 O  "O3'"  B U   B 1 2 ? 12.43456 11.60587 19.22169 0.516 17.11786 ? 2   U   B "O3'"  1
+ATOM   461 C  "C2'"  A U   B 1 2 ? 12.87616 11.70417 16.91148 0.484 32.66055 ? 2   U   B "C2'"  1
+ATOM   462 C  "C2'"  B U   B 1 2 ? 12.91026 11.73238 16.84972 0.516 16.15345 ? 2   U   B "C2'"  1
+ATOM   463 O  "O2'"  A U   B 1 2 ? 13.26433 13.04463 17.12898 0.484 34.74712 ? 2   U   B "O2'"  1
+ATOM   464 O  "O2'"  B U   B 1 2 ? 13.32416 13.06449 17.05178 0.516 17.54497 ? 2   U   B "O2'"  1
+ATOM   465 C  "C1'"  A U   B 1 2 ? 14.06682 10.75840 16.99294 0.484 33.83600 ? 2   U   B "C1'"  1
+ATOM   466 C  "C1'"  B U   B 1 2 ? 14.07543 10.74543 16.89964 0.516 16.52121 ? 2   U   B "C1'"  1
+ATOM   467 N  N1     A U   B 1 2 ? 14.85806 10.69125 15.75722 0.484 36.98040 ? 2   U   B N1     1
+ATOM   468 N  N1     B U   B 1 2 ? 14.84888 10.66772 15.65200 0.516 18.20928 ? 2   U   B N1     1
+ATOM   469 C  C2     A U   B 1 2 ? 16.23277 10.79455 15.85983 0.484 39.11634 ? 2   U   B C2     1
+ATOM   470 C  C2     B U   B 1 2 ? 16.22134 10.81454 15.71736 0.516 19.74635 ? 2   U   B C2     1
+ATOM   471 O  O2     A U   B 1 2 ? 16.82528 10.91738 16.91959 0.484 39.89987 ? 2   U   B O2     1
+ATOM   472 O  O2     B U   B 1 2 ? 16.81812 11.00911 16.76599 0.516 20.64911 ? 2   U   B O2     1
+ATOM   473 N  N3     A U   B 1 2 ? 16.89909 10.73452 14.66397 0.484 39.99330 ? 2   U   B N3     1
+ATOM   474 N  N3     B U   B 1 2 ? 16.87100 10.72873 14.50624 0.516 19.83704 ? 2   U   B N3     1
+ATOM   475 C  C4     A U   B 1 2 ? 16.34543 10.59464 13.40898 0.484 40.28108 ? 2   U   B C4     1
+ATOM   476 C  C4     B U   B 1 2 ? 16.29924 10.51822 13.26845 0.516 21.25667 ? 2   U   B C4     1
+ATOM   477 O  O4     A U   B 1 2 ? 17.08720 10.55690 12.42889 0.484 41.59160 ? 2   U   B O4     1
+ATOM   478 O  O4     B U   B 1 2 ? 17.02312 10.45527 12.27230 0.516 23.76013 ? 2   U   B O4     1
+ATOM   479 C  C5     A U   B 1 2 ? 14.91936 10.50359 13.38176 0.484 39.17195 ? 2   U   B C5     1
+ATOM   480 C  C5     B U   B 1 2 ? 14.87894 10.36830 13.28199 0.516 20.46392 ? 2   U   B C5     1
+ATOM   481 C  C6     A U   B 1 2 ? 14.24667 10.55722 14.53311 0.484 38.13743 ? 2   U   B C6     1
+ATOM   482 C  C6     B U   B 1 2 ? 14.23151 10.44347 14.44593 0.516 19.08886 ? 2   U   B C6     1
+ATOM   483 H  "H5'"  A U   B 1 2 ? 11.51585 7.87500  17.25018 0.484 30.83349 ? 2   U   B "H5'"  1
+ATOM   484 H  "H5'"  B U   B 1 2 ? 11.39631 8.09110  16.76039 0.516 18.27946 ? 2   U   B "H5'"  1
+ATOM   485 H  "H5''" A U   B 1 2 ? 10.38961 8.82922  17.81188 0.484 30.83349 ? 2   U   B "H5''" 1
+ATOM   486 H  "H5''" B U   B 1 2 ? 10.29112 8.99676  17.43329 0.516 18.27946 ? 2   U   B "H5''" 1
+ATOM   487 H  "H4'"  A U   B 1 2 ? 12.37236 9.32417  18.86991 0.484 34.26633 ? 2   U   B "H4'"  1
+ATOM   488 H  "H4'"  B U   B 1 2 ? 12.21748 9.25483  18.66840 0.516 17.87567 ? 2   U   B "H4'"  1
+ATOM   489 H  "H3'"  A U   B 1 2 ? 11.02524 11.30345 17.77329 0.484 34.30316 ? 2   U   B "H3'"  1
+ATOM   490 H  "H3'"  B U   B 1 2 ? 11.07198 11.42884 17.78400 0.516 18.36771 ? 2   U   B "H3'"  1
+ATOM   491 H  "H2'"  A U   B 1 2 ? 12.45253 11.61895 16.04305 0.484 39.19902 ? 2   U   B "H2'"  1
+ATOM   492 H  "H2'"  B U   B 1 2 ? 12.47185 11.66537 15.98704 0.516 19.39050 ? 2   U   B "H2'"  1
+ATOM   493 H  "HO2'" A U   B 1 2 ? 14.09411 13.07175 17.25681 0.484 41.70290 ? 2   U   B "HO2'" 1
+ATOM   494 H  "HO2'" B U   B 1 2 ? 14.14224 13.07077 17.24229 0.516 21.06032 ? 2   U   B "HO2'" 1
+ATOM   495 H  "H1'"  A U   B 1 2 ? 14.64729 11.01584 17.72621 0.484 40.60956 ? 2   U   B "H1'"  1
+ATOM   496 H  "H1'"  B U   B 1 2 ? 14.67359 10.97407 17.62822 0.516 19.83181 ? 2   U   B "H1'"  1
+ATOM   497 H  H3     A U   B 1 2 ? 17.75652 10.79018 14.70017 0.484 47.99832 ? 2   U   B H3     1
+ATOM   498 H  H3     B U   B 1 2 ? 17.72640 10.81586 14.52332 0.516 23.81081 ? 2   U   B H3     1
+ATOM   499 H  H5     A U   B 1 2 ? 14.46739 10.40848 12.57455 0.484 47.01270 ? 2   U   B H5     1
+ATOM   500 H  H5     B U   B 1 2 ? 14.41243 10.22047 12.49116 0.516 24.56306 ? 2   U   B H5     1
+ATOM   501 H  H6     A U   B 1 2 ? 13.31876 10.50116 14.50609 0.484 45.77128 ? 2   U   B H6     1
+ATOM   502 H  H6     B U   B 1 2 ? 13.30755 10.33779 14.44031 0.516 22.91299 ? 2   U   B H6     1
+ATOM   503 P  P      A G   B 1 3 ? 11.16281 12.10666 20.25801 0.484 18.89939 ? 3   G   B P      1
+ATOM   504 P  P      B G   B 1 3 ? 11.36566 11.83881 20.40245 0.516 24.35981 ? 3   G   B P      1
+ATOM   505 O  OP1    A G   B 1 3 ? 11.80932 12.69956 21.45217 0.484 22.93035 ? 3   G   B OP1    1
+ATOM   506 O  OP1    B G   B 1 3 ? 12.12089 12.27779 21.60626 0.516 27.84292 ? 3   G   B OP1    1
+ATOM   507 O  OP2    A G   B 1 3 ? 10.21533 10.96850 20.39057 0.484 20.22576 ? 3   G   B OP2    1
+ATOM   508 O  OP2    B G   B 1 3 ? 10.48689 10.64941 20.48844 0.516 26.40870 ? 3   G   B OP2    1
+ATOM   509 O  "O5'"  A G   B 1 3 ? 10.40054 13.27079 19.49386 0.484 13.45003 ? 3   G   B "O5'"  1
+ATOM   510 O  "O5'"  B G   B 1 3 ? 10.48929 13.07058 19.90205 0.516 23.17731 ? 3   G   B "O5'"  1
+ATOM   511 C  "C5'"  A G   B 1 3 ? 11.05547 14.48170 19.16027 0.484 13.15084 ? 3   G   B "C5'"  1
+ATOM   512 C  "C5'"  B G   B 1 3 ? 11.10878 14.23412 19.37077 0.516 22.03952 ? 3   G   B "C5'"  1
+ATOM   513 C  "C4'"  A G   B 1 3 ? 10.26562 15.66440 19.64556 0.484 9.84101  ? 3   G   B "C4'"  1
+ATOM   514 C  "C4'"  B G   B 1 3 ? 10.40322 15.49871 19.79666 0.516 19.21104 ? 3   G   B "C4'"  1
+ATOM   515 O  "O4'"  A G   B 1 3 ? 8.93990  15.64459 19.02993 0.484 8.21580  ? 3   G   B "O4'"  1
+ATOM   516 O  "O4'"  B G   B 1 3 ? 9.14291  15.63998 19.06195 0.516 18.15077 ? 3   G   B "O4'"  1
+ATOM   517 C  "C3'"  A G   B 1 3 ? 10.01893 15.74126 21.15899 0.484 10.86718 ? 3   G   B "C3'"  1
+ATOM   518 C  "C3'"  B G   B 1 3 ? 10.04717 15.60447 21.29150 0.516 18.25095 ? 3   G   B "C3'"  1
+ATOM   519 O  "O3'"  A G   B 1 3 ? 10.01323 17.10994 21.55727 0.484 12.03877 ? 3   G   B "O3'"  1
+ATOM   520 O  "O3'"  B G   B 1 3 ? 10.32707 16.92750 21.76355 0.516 13.69687 ? 3   G   B "O3'"  1
+ATOM   521 C  "C2'"  A G   B 1 3 ? 8.58844  15.25063 21.27624 0.484 7.91119  ? 3   G   B "C2'"  1
+ATOM   522 C  "C2'"  B G   B 1 3 ? 8.55024  15.35907 21.28591 0.516 19.89154 ? 3   G   B "C2'"  1
+ATOM   523 O  "O2'"  A G   B 1 3 ? 7.93589  15.63606 22.46733 0.484 9.02672  ? 3   G   B "O2'"  1
+ATOM   524 O  "O2'"  B G   B 1 3 ? 7.85414  15.86231 22.40122 0.516 23.67980 ? 3   G   B "O2'"  1
+ATOM   525 C  "C1'"  A G   B 1 3 ? 8.00461  15.91009 20.02523 0.484 8.51902  ? 3   G   B "C1'"  1
+ATOM   526 C  "C1'"  B G   B 1 3 ? 8.14793  16.02623 19.96672 0.516 16.72568 ? 3   G   B "C1'"  1
+ATOM   527 N  N9     A G   B 1 3 ? 6.65138  15.49614 19.68444 0.484 8.92012  ? 3   G   B N9     1
+ATOM   528 N  N9     B G   B 1 3 ? 6.80017  15.64343 19.55605 0.516 9.77735  ? 3   G   B N9     1
+ATOM   529 C  C8     A G   B 1 3 ? 6.11766  14.24313 19.65767 0.484 9.20030  ? 3   G   B C8     1
+ATOM   530 C  C8     B G   B 1 3 ? 6.30690  14.36978 19.51863 0.516 9.66255  ? 3   G   B C8     1
+ATOM   531 N  N7     A G   B 1 3 ? 4.83663  14.26555 19.49887 0.484 7.80382  ? 3   G   B N7     1
+ATOM   532 N  N7     B G   B 1 3 ? 5.03504  14.34311 19.29614 0.516 8.41807  ? 3   G   B N7     1
+ATOM   533 C  C5     A G   B 1 3 ? 4.50504  15.60842 19.44895 0.484 6.78002  ? 3   G   B C5     1
+ATOM   534 C  C5     B G   B 1 3 ? 4.65288  15.67206 19.23284 0.516 8.61736  ? 3   G   B C5     1
+ATOM   535 C  C6     A G   B 1 3 ? 3.26932  16.24873 19.29509 0.484 4.53507  ? 3   G   B C6     1
+ATOM   536 C  C6     B G   B 1 3 ? 3.38933  16.26485 19.00631 0.516 10.82209 ? 3   G   B C6     1
+ATOM   537 O  O6     A G   B 1 3 ? 2.17919  15.71029 19.18519 0.484 4.01763  ? 3   G   B O6     1
+ATOM   538 O  O6     B G   B 1 3 ? 2.30879  15.70895 18.81283 0.516 12.96448 ? 3   G   B O6     1
+ATOM   539 N  N1     A G   B 1 3 ? 3.38857  17.63093 19.33324 0.484 4.42489  ? 3   G   B N1     1
+ATOM   540 N  N1     B G   B 1 3 ? 3.44479  17.65227 19.02185 0.516 10.76179 ? 3   G   B N1     1
+ATOM   541 C  C2     A G   B 1 3 ? 4.56135  18.32842 19.43783 0.484 7.50379  ? 3   G   B C2     1
+ATOM   542 C  C2     B G   B 1 3 ? 4.57939  18.40324 19.21795 0.516 8.17364  ? 3   G   B C2     1
+ATOM   543 N  N2     A G   B 1 3 ? 4.47910  19.65642 19.43940 0.484 7.65014  ? 3   G   B N2     1
+ATOM   544 N  N2     B G   B 1 3 ? 4.43586  19.72558 19.20593 0.516 8.91801  ? 3   G   B N2     1
+ATOM   545 N  N3     A G   B 1 3 ? 5.71985  17.72648 19.57345 0.484 9.33336  ? 3   G   B N3     1
+ATOM   546 N  N3     B G   B 1 3 ? 5.75754  17.84780 19.37926 0.516 7.15291  ? 3   G   B N3     1
+ATOM   547 C  C4     A G   B 1 3 ? 5.60830  16.38085 19.56365 0.484 8.70874  ? 3   G   B C4     1
+ATOM   548 C  C4     B G   B 1 3 ? 5.72148  16.49608 19.39804 0.516 7.65919  ? 3   G   B C4     1
+ATOM   549 H  "H5'"  A G   B 1 3 ? 11.15540 14.53685 18.19700 0.484 15.78737 ? 3   G   B "H5'"  1
+ATOM   550 H  "H5'"  B G   B 1 3 ? 11.10059 14.18037 18.40230 0.516 26.45379 ? 3   G   B "H5'"  1
+ATOM   551 H  "H5''" A G   B 1 3 ? 11.93453 14.49374 19.57016 0.484 15.78737 ? 3   G   B "H5''" 1
+ATOM   552 H  "H5''" B G   B 1 3 ? 12.02840 14.26861 19.67738 0.516 26.45379 ? 3   G   B "H5''" 1
+ATOM   553 H  "H4'"  A G   B 1 3 ? 10.73503 16.46764 19.37104 0.484 11.81558 ? 3   G   B "H4'"  1
+ATOM   554 H  "H4'"  B G   B 1 3 ? 10.97495 16.24759 19.56600 0.516 23.05960 ? 3   G   B "H4'"  1
+ATOM   555 H  "H3'"  A G   B 1 3 ? 10.65708 15.19905 21.64856 0.484 13.04698 ? 3   G   B "H3'"  1
+ATOM   556 H  "H3'"  B G   B 1 3 ? 10.51526 14.93992 21.82080 0.516 21.90750 ? 3   G   B "H3'"  1
+ATOM   557 H  "H2'"  A G   B 1 3 ? 8.53149  14.28523 21.20106 0.484 9.49978  ? 3   G   B "H2'"  1
+ATOM   558 H  "H2'"  B G   B 1 3 ? 8.37203  14.40755 21.22454 0.516 23.87620 ? 3   G   B "H2'"  1
+ATOM   559 H  "HO2'" A G   B 1 3 ? 7.15031  15.87109 22.28504 0.484 10.83842 ? 3   G   B "HO2'" 1
+ATOM   560 H  "HO2'" B G   B 1 3 ? 8.09368  15.43978 23.08656 0.516 28.42212 ? 3   G   B "HO2'" 1
+ATOM   561 H  "H1'"  A G   B 1 3 ? 7.95261  16.87455 20.11477 0.484 10.22918 ? 3   G   B "H1'"  1
+ATOM   562 H  "H1'"  B G   B 1 3 ? 8.17607  16.99549 19.99199 0.516 20.07717 ? 3   G   B "H1'"  1
+ATOM   563 H  H8     A G   B 1 3 ? 6.61721  13.46341 19.74366 0.484 11.04672 ? 3   G   B H8     1
+ATOM   564 H  H8     B G   B 1 3 ? 6.82769  13.60883 19.63958 0.516 11.60142 ? 3   G   B H8     1
+ATOM   565 H  H1     A G   B 1 3 ? 2.66219  18.08902 19.28714 0.484 5.31623  ? 3   G   B H1     1
+ATOM   566 H  H1     B G   B 1 3 ? 2.70747  18.07739 18.89844 0.516 12.92051 ? 3   G   B H1     1
+ATOM   567 H  H21    A G   B 1 3 ? 3.71461  20.04000 19.34978 0.484 9.18653  ? 3   G   B H21    1
+ATOM   568 H  H21    B G   B 1 3 ? 3.65625  20.07253 19.09906 0.516 10.70797 ? 3   G   B H21    1
+ATOM   569 H  H22    A G   B 1 3 ? 5.19042  20.13119 19.53003 0.484 9.18653  ? 3   G   B H22    1
+ATOM   570 H  H22    B G   B 1 3 ? 5.12269  20.23358 19.30502 0.516 10.70797 ? 3   G   B H22    1
+ATOM   571 P  P      A U   B 1 4 ? 11.25942 17.87152 22.19593 0.484 13.95186 ? 4   U   B P      1
+ATOM   572 P  P      B U   B 1 4 ? 10.17668 17.37057 23.30993 0.516 17.03824 ? 4   U   B P      1
+ATOM   573 O  OP1    A U   B 1 4 ? 12.19132 18.30115 21.12124 0.484 16.35023 ? 4   U   B OP1    1
+ATOM   574 O  OP1    B U   B 1 4 ? 11.46867 17.91528 23.77812 0.516 22.02378 ? 4   U   B OP1    1
+ATOM   575 O  OP2    A U   B 1 4 ? 11.75500 17.11290 23.36709 0.484 15.81959 ? 4   U   B OP2    1
+ATOM   576 O  OP2    B U   B 1 4 ? 9.52745  16.29207 24.09150 0.516 19.23248 ? 4   U   B OP2    1
+ATOM   577 O  "O5'"  A U   B 1 4 ? 10.55545 19.18781 22.72458 0.484 13.15644 ? 4   U   B "O5'"  1
+ATOM   578 O  "O5'"  B U   B 1 4 ? 9.10427  18.53162 23.20622 0.516 14.07133 ? 4   U   B "O5'"  1
+ATOM   579 C  "C5'"  A U   B 1 4 ? 9.41474  19.08929 23.54900 0.484 12.25277 ? 4   U   B "C5'"  1
+ATOM   580 C  "C5'"  B U   B 1 4 ? 9.40032  19.70620 22.46363 0.516 11.33998 ? 4   U   B "C5'"  1
+ATOM   581 C  "C4'"  A U   B 1 4 ? 8.42232  20.16785 23.22608 0.484 9.99936  ? 4   U   B "C4'"  1
+ATOM   582 C  "C4'"  B U   B 1 4 ? 8.25203  20.67768 22.51739 0.516 10.24043 ? 4   U   B "C4'"  1
+ATOM   583 O  "O4'"  A U   B 1 4 ? 7.45552  19.70590 22.24966 0.484 9.25841  ? 4   U   B "O4'"  1
+ATOM   584 O  "O4'"  B U   B 1 4 ? 7.12854  20.18911 21.74533 0.516 9.55598  ? 4   U   B "O4'"  1
+ATOM   585 C  "C3'"  A U   B 1 4 ? 7.56486  20.63576 24.38430 0.484 10.59464 ? 4   U   B "C3'"  1
+ATOM   586 C  "C3'"  B U   B 1 4 ? 7.66468  20.90626 23.89239 0.516 9.86762  ? 4   U   B "C3'"  1
+ATOM   587 O  "O3'"  A U   B 1 4 ? 8.25393  21.53665 25.22155 0.484 11.67695 ? 4   U   B "O3'"  1
+ATOM   588 O  "O3'"  B U   B 1 4 ? 8.45744  21.79141 24.64667 0.516 10.96453 ? 4   U   B "O3'"  1
+ATOM   589 C  "C2'"  A U   B 1 4 ? 6.37795  21.26321 23.67215 0.484 9.87278  ? 4   U   B "C2'"  1
+ATOM   590 C  "C2'"  B U   B 1 4 ? 6.27185  21.43572 23.57612 0.516 10.65696 ? 4   U   B "C2'"  1
+ATOM   591 O  "O2'"  A U   B 1 4 ? 6.70400  22.55057 23.14928 0.484 11.79574 ? 4   U   B "O2'"  1
+ATOM   592 O  "O2'"  B U   B 1 4 ? 6.30390  22.80858 23.20066 0.516 13.13820 ? 4   U   B "O2'"  1
+ATOM   593 C  "C1'"  A U   B 1 4 ? 6.19859  20.30546 22.50459 0.484 9.19128  ? 4   U   B "C1'"  1
+ATOM   594 C  "C1'"  B U   B 1 4 ? 5.91501  20.61013 22.34432 0.516 9.84355  ? 4   U   B "C1'"  1
+ATOM   595 N  N1     A U   B 1 4 ? 5.19600  19.23358 22.71130 0.484 7.22772  ? 4   U   B N1     1
+ATOM   596 N  N1     B U   B 1 4 ? 5.05509  19.42356 22.58929 0.516 11.07976 ? 4   U   B N1     1
+ATOM   597 C  C2     A U   B 1 4 ? 3.86520  19.57984 22.73340 0.484 6.69997  ? 4   U   B C2     1
+ATOM   598 C  C2     B U   B 1 4 ? 3.70640  19.67446 22.70694 0.516 11.06244 ? 4   U   B C2     1
+ATOM   599 O  O2     A U   B 1 4 ? 3.50853  20.74627 22.67290 0.484 8.07665  ? 4   U   B O2     1
+ATOM   600 O  O2     B U   B 1 4 ? 3.23837  20.79915 22.70392 0.516 11.20348 ? 4   U   B O2     1
+ATOM   601 N  N3     A U   B 1 4 ? 2.99217  18.51891 22.81454 0.484 6.32154  ? 4   U   B N3     1
+ATOM   602 N  N3     B U   B 1 4 ? 2.91327  18.56214 22.84112 0.516 9.78903  ? 4   U   B N3     1
+ATOM   603 C  C4     A U   B 1 4 ? 3.32090  17.18673 22.88964 0.484 6.32877  ? 4   U   B C4     1
+ATOM   604 C  C4     B U   B 1 4 ? 3.33615  17.24732 22.85698 0.516 9.58777  ? 4   U   B C4     1
+ATOM   605 O  O4     A U   B 1 4 ? 2.42389  16.35567 22.95623 0.484 6.41768  ? 4   U   B O4     1
+ATOM   606 O  O4     B U   B 1 4 ? 2.48831  16.35998 22.98823 0.516 9.27441  ? 4   U   B O4     1
+ATOM   607 C  C5     A U   B 1 4 ? 4.72142  16.90936 22.85427 0.484 6.78082  ? 4   U   B C5     1
+ATOM   608 C  C5     B U   B 1 4 ? 4.74404  17.05873 22.72062 0.516 9.88622  ? 4   U   B C5     1
+ATOM   609 C  C6     A U   B 1 4 ? 5.58609  17.92485 22.75193 0.484 6.75624  ? 4   U   B C6     1
+ATOM   610 C  C6     B U   B 1 4 ? 5.53407  18.13189 22.57856 0.516 11.44598 ? 4   U   B C6     1
+ATOM   611 H  "H5'"  A U   B 1 4 ? 9.68405  19.17117 24.47726 0.484 14.70968 ? 4   U   B "H5'"  1
+ATOM   612 H  "H5'"  B U   B 1 4 ? 9.57236  19.46546 21.53986 0.516 13.61433 ? 4   U   B "H5'"  1
+ATOM   613 H  "H5''" A U   B 1 4 ? 8.99896  18.22307 23.41603 0.484 14.70968 ? 4   U   B "H5''" 1
+ATOM   614 H  "H5''" B U   B 1 4 ? 10.19243 20.12682 22.83314 0.516 13.61433 ? 4   U   B "H5''" 1
+ATOM   615 H  "H4'"  A U   B 1 4 ? 8.90109  20.92083 22.84570 0.484 12.00559 ? 4   U   B "H4'"  1
+ATOM   616 H  "H4'"  B U   B 1 4 ? 8.54028  21.52073 22.13387 0.516 12.29487 ? 4   U   B "H4'"  1
+ATOM   617 H  "H3'"  A U   B 1 4 ? 7.26186  19.87313 24.90148 0.484 12.71993 ? 4   U   B "H3'"  1
+ATOM   618 H  "H3'"  B U   B 1 4 ? 7.56978  20.06402 24.36412 0.516 11.84751 ? 4   U   B "H3'"  1
+ATOM   619 H  "H2'"  A U   B 1 4 ? 5.59602  21.29910 24.24505 0.484 11.85370 ? 4   U   B "H2'"  1
+ATOM   620 H  "H2'"  B U   B 1 4 ? 5.65979  21.28426 24.31324 0.516 12.79471 ? 4   U   B "H2'"  1
+ATOM   621 H  "HO2'" A U   B 1 4 ? 6.78734  23.09148 23.78652 0.484 14.16125 ? 4   U   B "HO2'" 1
+ATOM   622 H  "HO2'" B U   B 1 4 ? 6.34211  22.86226 22.36325 0.516 15.77220 ? 4   U   B "HO2'" 1
+ATOM   623 H  "H1'"  A U   B 1 4 ? 5.90582  20.82876 21.74213 0.484 11.03589 ? 4   U   B "H1'"  1
+ATOM   624 H  "H1'"  B U   B 1 4 ? 5.42205  21.18972 21.74268 0.516 11.81862 ? 4   U   B "H1'"  1
+ATOM   625 H  H3     A U   B 1 4 ? 2.15358  18.70956 22.81868 0.484 7.59221  ? 4   U   B H3     1
+ATOM   626 H  H3     B U   B 1 4 ? 2.06801  18.69755 22.92360 0.516 11.75319 ? 4   U   B H3     1
+ATOM   627 H  H5     A U   B 1 4 ? 5.02870  16.03288 22.90184 0.484 8.14334  ? 4   U   B H5     1
+ATOM   628 H  H5     B U   B 1 4 ? 5.10825  16.20306 22.73021 0.516 11.86982 ? 4   U   B H5     1
+ATOM   629 H  H6     A U   B 1 4 ? 6.49454  17.73109 22.70634 0.484 8.11385  ? 4   U   B H6     1
+ATOM   630 H  H6     B U   B 1 4 ? 6.44774  17.99851 22.46761 0.516 13.74154 ? 4   U   B H6     1
+ATOM   631 P  P      A G   B 1 5 ? 8.54428  21.21140 26.76694 0.484 12.27649 ? 5   G   B P      1
+ATOM   632 P  P      B G   B 1 5 ? 8.79503  21.50056 26.19749 0.516 9.37387  ? 5   G   B P      1
+ATOM   633 O  OP1    A G   B 1 5 ? 9.91055  21.70412 27.07871 0.484 12.44771 ? 5   G   B OP1    1
+ATOM   634 O  OP1    B G   B 1 5 ? 10.05086 22.22224 26.46554 0.516 9.74263  ? 5   G   B OP1    1
+ATOM   635 O  OP2    A G   B 1 5 ? 8.17951  19.80025 27.05841 0.484 12.62665 ? 5   G   B OP2    1
+ATOM   636 O  OP2    B G   B 1 5 ? 8.65354  20.04392 26.48636 0.516 10.08741 ? 5   G   B OP2    1
+ATOM   637 O  "O5'"  A G   B 1 5 ? 7.50464  22.14908 27.51804 0.484 11.94655 ? 5   G   B "O5'"  1
+ATOM   638 O  "O5'"  B G   B 1 5 ? 7.60446  22.21905 26.97640 0.516 9.82675  ? 5   G   B "O5'"  1
+ATOM   639 C  "C5'"  A G   B 1 5 ? 7.48372  23.54702 27.25984 0.484 12.50355 ? 5   G   B "C5'"  1
+ATOM   640 C  "C5'"  B G   B 1 5 ? 7.57171  23.63765 27.06045 0.516 11.92952 ? 5   G   B "C5'"  1
+ATOM   641 C  "C4'"  A G   B 1 5 ? 6.09918  24.10143 27.40919 0.484 10.89506 ? 5   G   B "C4'"  1
+ATOM   642 C  "C4'"  B G   B 1 5 ? 6.20391  24.14232 27.42525 0.516 10.99930 ? 5   G   B "C4'"  1
+ATOM   643 O  "O4'"  A G   B 1 5 ? 5.27526  23.62083 26.32037 0.484 10.39182 ? 5   G   B "O4'"  1
+ATOM   644 O  "O4'"  B G   B 1 5 ? 5.27027  23.75105 26.39307 0.516 10.48386 ? 5   G   B "O4'"  1
+ATOM   645 C  "C3'"  A G   B 1 5 ? 5.35753  23.67003 28.65866 0.484 11.65791 ? 5   G   B "C3'"  1
+ATOM   646 C  "C3'"  B G   B 1 5 ? 5.60001  23.58109 28.69617 0.516 10.02200 ? 5   G   B "C3'"  1
+ATOM   647 O  "O3'"  A G   B 1 5 ? 5.69889  24.45232 29.78103 0.484 12.04849 ? 5   G   B "O3'"  1
+ATOM   648 O  "O3'"  B G   B 1 5 ? 6.04904  24.24630 29.85449 0.516 11.83432 ? 5   G   B "O3'"  1
+ATOM   649 C  "C2'"  A G   B 1 5 ? 3.90496  23.81497 28.24603 0.484 11.79889 ? 5   G   B "C2'"  1
+ATOM   650 C  "C2'"  B G   B 1 5 ? 4.11031  23.75276 28.45986 0.516 10.93510 ? 5   G   B "C2'"  1
+ATOM   651 O  "O2'"  A G   B 1 5 ? 3.49763  25.17686 28.29219 0.484 14.47245 ? 5   G   B "O2'"  1
+ATOM   652 O  "O2'"  B G   B 1 5 ? 3.69987  25.09357 28.68313 0.516 13.36481 ? 5   G   B "O2'"  1
+ATOM   653 C  "C1'"  A G   B 1 5 ? 3.96738  23.37553 26.78747 0.484 9.16212  ? 5   G   B "C1'"  1
+ATOM   654 C  "C1'"  B G   B 1 5 ? 4.01596  23.45122 26.97345 0.516 9.60303  ? 5   G   B "C1'"  1
+ATOM   655 N  N9     A G   B 1 5 ? 3.68475  21.94799 26.59367 0.484 8.77756  ? 5   G   B N9     1
+ATOM   656 N  N9     B G   B 1 5 ? 3.71873  22.03997 26.72359 0.516 7.88146  ? 5   G   B N9     1
+ATOM   657 C  C8     A G   B 1 5 ? 4.56612  20.89949 26.49056 0.484 9.15053  ? 5   G   B C8     1
+ATOM   658 C  C8     B G   B 1 5 ? 4.59877  20.99489 26.61735 0.516 7.46254  ? 5   G   B C8     1
+ATOM   659 N  N7     A G   B 1 5 ? 3.98305  19.74838 26.27738 0.484 8.76396  ? 5   G   B N7     1
+ATOM   660 N  N7     B G   B 1 5 ? 4.01288  19.85546 26.36204 0.516 6.79441  ? 5   G   B N7     1
+ATOM   661 C  C5     A G   B 1 5 ? 2.64220  20.06157 26.24476 0.484 7.90671  ? 5   G   B C5     1
+ATOM   662 C  C5     B G   B 1 5 ? 2.67010  20.17073 26.32243 0.516 6.94926  ? 5   G   B C5     1
+ATOM   663 C  C6     A G   B 1 5 ? 1.52114  19.22353 26.06055 0.484 6.87487  ? 5   G   B C6     1
+ATOM   664 C  C6     B G   B 1 5 ? 1.55759  19.32979 26.08933 0.516 7.54685  ? 5   G   B C6     1
+ATOM   665 O  O6     A G   B 1 5 ? 1.44486  18.00084 25.85566 0.484 5.75416  ? 5   G   B O6     1
+ATOM   666 O  O6     B G   B 1 5 ? 1.53918  18.10317 25.87588 0.516 7.52872  ? 5   G   B O6     1
+ATOM   667 N  N1     A G   B 1 5 ? 0.35306  19.94920 26.10959 0.484 6.73244  ? 5   G   B N1     1
+ATOM   668 N  N1     B G   B 1 5 ? 0.36260  20.04262 26.16038 0.516 7.14400  ? 5   G   B N1     1
+ATOM   669 C  C2     A G   B 1 5 ? 0.26160  21.29431 26.31123 0.484 7.81033  ? 5   G   B C2     1
+ATOM   670 C  C2     B G   B 1 5 ? 0.26233  21.39739 26.39212 0.516 7.69087  ? 5   G   B C2     1
+ATOM   671 N  N2     A G   B 1 5 ? -0.96692 21.81485 26.32892 0.484 9.50251  ? 5   G   B N2     1
+ATOM   672 N  N2     B G   B 1 5 ? -0.96959 21.93340 26.42853 0.516 7.89279  ? 5   G   B N2     1
+ATOM   673 N  N3     A G   B 1 5 ? 1.29735  22.09015 26.47572 0.484 8.62921  ? 5   G   B N3     1
+ATOM   674 N  N3     B G   B 1 5 ? 1.30973  22.18426 26.59399 0.516 7.31072  ? 5   G   B N3     1
+ATOM   675 C  C4     A G   B 1 5 ? 2.44591  21.41038 26.43651 0.484 8.68122  ? 5   G   B C4     1
+ATOM   676 C  C4     B G   B 1 5 ? 2.47063  21.51446 26.54754 0.516 7.13469  ? 5   G   B C4     1
+ATOM   677 H  "H5'"  A G   B 1 5 ? 7.79627  23.70902 26.35597 0.484 15.01062 ? 5   G   B "H5'"  1
+ATOM   678 H  "H5'"  B G   B 1 5 ? 7.82795  24.01106 26.20266 0.516 14.32179 ? 5   G   B "H5'"  1
+ATOM   679 H  "H5''" A G   B 1 5 ? 8.07575  23.99540 27.88382 0.484 15.01062 ? 5   G   B "H5''" 1
+ATOM   680 H  "H5''" B G   B 1 5 ? 8.20608  23.92906 27.73392 0.516 14.32179 ? 5   G   B "H5''" 1
+ATOM   681 H  "H4'"  A G   B 1 5 ? 6.12825  25.07053 27.37911 0.484 13.08044 ? 5   G   B "H4'"  1
+ATOM   682 H  "H4'"  B G   B 1 5 ? 6.22700  25.10942 27.49657 0.516 13.20552 ? 5   G   B "H4'"  1
+ATOM   683 H  "H3'"  A G   B 1 5 ? 5.54596  22.73609 28.84074 0.484 13.99585 ? 5   G   B "H3'"  1
+ATOM   684 H  "H3'"  B G   B 1 5 ? 5.81452  22.63699 28.75588 0.516 12.03276 ? 5   G   B "H3'"  1
+ATOM   685 H  "H2'"  A G   B 1 5 ? 3.31979  23.24752 28.77183 0.484 14.16503 ? 5   G   B "H2'"  1
+ATOM   686 H  "H2'"  B G   B 1 5 ? 3.58735  23.13285 28.99196 0.516 13.12848 ? 5   G   B "H2'"  1
+ATOM   687 H  "HO2'" A G   B 1 5 ? 3.47779  25.42938 29.09309 0.484 17.37331 ? 5   G   B "HO2'" 1
+ATOM   688 H  "HO2'" B G   B 1 5 ? 3.75478  25.26330 29.50397 0.516 16.04414 ? 5   G   B "HO2'" 1
+ATOM   689 H  "H1'"  A G   B 1 5 ? 3.32288  23.89852 26.28548 0.484 11.00090 ? 5   G   B "H1'"  1
+ATOM   690 H  "H1'"  B G   B 1 5 ? 3.33121  24.00839 26.57148 0.516 11.52999 ? 5   G   B "H1'"  1
+ATOM   691 H  H8     A G   B 1 5 ? 5.48783  20.99851 26.56510 0.484 10.98699 ? 5   G   B H8     1
+ATOM   692 H  H8     B G   B 1 5 ? 5.51881  21.08731 26.71680 0.516 8.96141  ? 5   G   B H8     1
+ATOM   693 H  H1     A G   B 1 5 ? -0.38281 19.51684 26.00391 0.484 8.08528  ? 5   G   B H1     1
+ATOM   694 H  H1     B G   B 1 5 ? -0.36868 19.60341 26.05121 0.516 8.57916  ? 5   G   B H1     1
+ATOM   695 H  H21    A G   B 1 5 ? -1.65144 21.30522 26.22259 0.484 11.40937 ? 5   G   B H21    1
+ATOM   696 H  H21    B G   B 1 5 ? -1.65902 21.43579 26.29946 0.516 9.47771  ? 5   G   B H21    1
+ATOM   697 H  H22    A G   B 1 5 ? -1.07418 22.65997 26.44666 0.484 11.40937 ? 5   G   B H22    1
+ATOM   698 H  H22    B G   B 1 5 ? -1.06845 22.77400 26.58089 0.516 9.47771  ? 5   G   B H22    1
+ATOM   699 P  P      A U   B 1 6 ? 5.54071  23.85888 31.26355 0.484 11.91522 ? 6   U   B P      1
+ATOM   700 P  P      B U   B 1 6 ? 6.07014  23.46264 31.24814 0.516 13.91651 ? 6   U   B P      1
+ATOM   701 O  OP1    A U   B 1 6 ? 4.21830  23.19794 31.39634 0.484 12.17969 ? 6   U   B OP1    1
+ATOM   702 O  OP1    B U   B 1 6 ? 4.75820  22.80788 31.49494 0.516 14.31594 ? 6   U   B OP1    1
+ATOM   703 O  OP2    A U   B 1 6 ? 5.90890  24.92078 32.20993 0.484 13.06106 ? 6   U   B OP2    1
+ATOM   704 O  OP2    B U   B 1 6 ? 6.56649  24.38222 32.27790 0.516 15.68720 ? 6   U   B OP2    1
+ATOM   705 O  "O5'"  A U   B 1 6 ? 6.65831  22.72735 31.32324 0.484 12.92793 ? 6   U   B "O5'"  1
+ATOM   706 O  "O5'"  B U   B 1 6 ? 7.15109  22.33319 30.97240 0.516 15.17809 ? 6   U   B "O5'"  1
+ATOM   707 C  "C5'"  A U   B 1 6 ? 7.00330  22.11505 32.56385 0.484 13.00616 ? 6   U   B "C5'"  1
+ATOM   708 C  "C5'"  B U   B 1 6 ? 7.76066  21.62520 32.04277 0.516 16.84583 ? 6   U   B "C5'"  1
+ATOM   709 C  "C4'"  A U   B 1 6 ? 7.33287  20.65185 32.40696 0.484 11.71571 ? 6   U   B "C4'"  1
+ATOM   710 C  "C4'"  B U   B 1 6 ? 7.98154  20.17117 31.70629 0.516 15.21503 ? 6   U   B "C4'"  1
+ATOM   711 O  "O4'"  A U   B 1 6 ? 6.09771  19.91258 32.19754 0.484 11.55168 ? 6   U   B "O4'"  1
+ATOM   712 O  "O4'"  B U   B 1 6 ? 6.69444  19.49438 31.69622 0.516 14.32853 ? 6   U   B "O4'"  1
+ATOM   713 C  "C3'"  A U   B 1 6 ? 8.24976  20.30447 31.23461 0.484 12.05924 ? 6   U   B "C3'"  1
+ATOM   714 C  "C3'"  B U   B 1 6 ? 8.61824  19.88081 30.33916 0.516 15.86237 ? 6   U   B "C3'"  1
+ATOM   715 O  "O3'"  A U   B 1 6 ? 9.18232  19.29683 31.62950 0.484 13.44414 ? 6   U   B "O3'"  1
+ATOM   716 O  "O3'"  B U   B 1 6 ? 9.49546  18.76071 30.44180 0.516 17.69473 ? 6   U   B "O3'"  1
+ATOM   717 C  "C2'"  A U   B 1 6 ? 7.27762  19.75069 30.18866 0.484 10.89540 ? 6   U   B "C2'"  1
+ATOM   718 C  "C2'"  B U   B 1 6 ? 7.41593  19.50216 29.48205 0.516 13.94026 ? 6   U   B "C2'"  1
+ATOM   719 O  "O2'"  A U   B 1 6 ? 7.85246  18.83096 29.28356 0.484 12.49167 ? 6   U   B "O2'"  1
+ATOM   720 O  "O2'"  B U   B 1 6 ? 7.69485  18.69769 28.35580 0.516 13.59882 ? 6   U   B "O2'"  1
+ATOM   721 C  "C1'"  A U   B 1 6 ? 6.22502  19.08361 31.06515 0.484 10.22243 ? 6   U   B "C1'"  1
+ATOM   722 C  "C1'"  B U   B 1 6 ? 6.56792  18.76013 30.49935 0.516 12.62009 ? 6   U   B "C1'"  1
+ATOM   723 N  N1     A U   B 1 6 ? 4.89137  18.94404 30.45961 0.484 9.18480  ? 6   U   B N1     1
+ATOM   724 N  N1     B U   B 1 6 ? 5.15943  18.67812 30.13242 0.516 9.75538  ? 6   U   B N1     1
+ATOM   725 C  C2     A U   B 1 6 ? 4.46912  17.67847 30.08134 0.484 8.90544  ? 6   U   B C2     1
+ATOM   726 C  C2     B U   B 1 6 ? 4.66744  17.44435 29.76019 0.516 8.37842  ? 6   U   B C2     1
+ATOM   727 O  O2     A U   B 1 6 ? 5.14298  16.66710 30.20928 0.484 9.04102  ? 6   U   B O2     1
+ATOM   728 O  O2     B U   B 1 6 ? 5.32605  16.42258 29.73470 0.516 9.42195  ? 6   U   B O2     1
+ATOM   729 N  N3     A U   B 1 6 ? 3.21563  17.64150 29.53744 0.484 8.30409  ? 6   U   B N3     1
+ATOM   730 N  N3     B U   B 1 6 ? 3.35864  17.46725 29.40427 0.516 7.08762  ? 6   U   B N3     1
+ATOM   731 C  C4     A U   B 1 6 ? 2.34133  18.68514 29.34552 0.484 7.77383  ? 6   U   B C4     1
+ATOM   732 C  C4     B U   B 1 6 ? 2.50206  18.53977 29.40570 0.516 7.57479  ? 6   U   B C4     1
+ATOM   733 O  O4     A U   B 1 6 ? 1.23880  18.47096 28.85542 0.484 7.55571  ? 6   U   B O4     1
+ATOM   734 O  O4     B U   B 1 6 ? 1.33423  18.36386 29.07486 0.516 7.75463  ? 6   U   B O4     1
+ATOM   735 C  C5     A U   B 1 6 ? 2.83507  19.95494 29.76131 0.484 8.56277  ? 6   U   B C5     1
+ATOM   736 C  C5     B U   B 1 6 ? 3.09422  19.78428 29.79107 0.516 8.25207  ? 6   U   B C5     1
+ATOM   737 C  C6     A U   B 1 6 ? 4.06469  20.03980 30.29158 0.484 8.81196  ? 6   U   B C6     1
+ATOM   738 C  C6     B U   B 1 6 ? 4.38526  19.81168 30.13066 0.516 9.27500  ? 6   U   B C6     1
+ATOM   739 H  "H5'"  A U   B 1 6 ? 6.25658  22.20466 33.17646 0.484 15.61375 ? 6   U   B "H5'"  1
+ATOM   740 H  "H5'"  B U   B 1 6 ? 7.18987  21.68423 32.82482 0.516 20.22136 ? 6   U   B "H5'"  1
+ATOM   741 H  "H5''" A U   B 1 6 ? 7.77367  22.57216 32.93597 0.484 15.61375 ? 6   U   B "H5''" 1
+ATOM   742 H  "H5''" B U   B 1 6 ? 8.61628  22.03517 32.24461 0.516 20.22136 ? 6   U   B "H5''" 1
+ATOM   743 H  "H4'"  A U   B 1 6 ? 7.75212  20.33624 33.22275 0.484 14.06521 ? 6   U   B "H4'"  1
+ATOM   744 H  "H4'"  B U   B 1 6 ? 8.54814  19.78315 32.39134 0.516 18.26439 ? 6   U   B "H4'"  1
+ATOM   745 H  "H3'"  A U   B 1 6 ? 8.70865  21.09082 30.89999 0.484 14.47744 ? 6   U   B "H3'"  1
+ATOM   746 H  "H3'"  B U   B 1 6 ? 9.07682  20.66210 29.99246 0.516 19.04121 ? 6   U   B "H3'"  1
+ATOM   747 H  "HO3'" A U   B 1 6 ? 9.18602  18.55234 31.24050 0.484 16.13932 ? 6   U   B "HO3'" 1
+ATOM   748 H  "H2'"  A U   B 1 6 ? 6.87673  20.48749 29.70151 0.484 13.08083 ? 6   U   B "H2'"  1
+ATOM   749 H  "H2'"  B U   B 1 6 ? 6.96847  20.31019 29.18578 0.516 16.73467 ? 6   U   B "H2'"  1
+ATOM   750 H  "H1'"  A U   B 1 6 ? 6.54618  18.20425 31.31909 0.484 12.27328 ? 6   U   B "H1'"  1
+ATOM   751 H  "H1'"  B U   B 1 6 ? 6.91175  17.86423 30.64093 0.516 15.15047 ? 6   U   B "H1'"  1
+ATOM   752 H  H3     A U   B 1 6 ? 2.93897  16.86792 29.28324 0.484 9.97127  ? 6   U   B H3     1
+ATOM   753 H  H3     B U   B 1 6 ? 3.02467  16.71797 29.14610 0.516 8.51151  ? 6   U   B H3     1
+ATOM   754 H  H5     A U   B 1 6 ? 2.31070  20.71711 29.66624 0.484 10.28168 ? 6   U   B H5     1
+ATOM   755 H  H5     B U   B 1 6 ? 2.58668  20.56346 29.80480 0.516 9.90884  ? 6   U   B H5     1
+ATOM   756 H  H6     A U   B 1 6 ? 4.37556  20.87463 30.55862 0.484 10.58072 ? 6   U   B H6     1
+ATOM   757 H  H6     B U   B 1 6 ? 4.77122  20.62234 30.37305 0.516 11.13636 ? 6   U   B H6     1
+HETATM 758 K  K      . K   C 2 . ? 0.00000  16.41050 14.34792 0.25  7.32970  ? 101 K   A K      1
+HETATM 759 K  K      . K   D 2 . ? 0.00000  16.41050 10.83489 0.25  8.06467  ? 102 K   A K      1
+HETATM 760 K  K      . K   E 2 . ? 0.00000  16.41050 4.51015  0.25  8.63406  ? 103 K   A K      1
+HETATM 761 K  K      . K   F 2 . ? 0.00000  16.41050 1.08820  0.25  8.75300  ? 104 K   A K      1
+HETATM 762 NA NA     . NA  G 3 . ? 7.56087  10.45259 0.59953  1.000 11.10551 ? 105 NA  A NA     1
+HETATM 763 K  K      . K   H 2 . ? 0.00000  16.41050 27.60385 0.25  6.33824  ? 101 K   B K      1
+HETATM 764 K  K      . K   I 2 . ? 0.00000  16.41050 24.08329 0.25  6.20047  ? 102 K   B K      1
+HETATM 765 K  K      . K   J 2 . ? 0.00000  16.41050 17.85017 0.25  7.36102  ? 103 K   B K      1
+HETATM 766 NA NA     . NA  K 3 . ? 9.37260  16.98855 28.63447 1.000 22.62292 ? 104 NA  B NA     1
+HETATM 767 O  O      . HOH L 4 . ? 13.41913 21.32239 15.18926 1.000 40.97199 ? 201 HOH A O      1
+HETATM 768 O  O      . HOH L 4 . ? 8.38442  16.63647 16.32425 1.000 15.96997 ? 202 HOH A O      1
+HETATM 769 O  O      . HOH L 4 . ? 17.71155 11.53938 9.94001  1.000 34.97351 ? 203 HOH A O      1
+HETATM 770 O  O      . HOH L 4 . ? 7.61777  8.59409  2.22827  1.000 10.32469 ? 204 HOH A O      1
+HETATM 771 O  O      . HOH L 4 . ? 2.039    5.387    7.282    1.000 24.09370 ? 205 HOH A O      1
+HETATM 772 O  O      . HOH L 4 . ? 7.40957  12.02376 2.35240  1.000 11.28442 ? 206 HOH A O      1
+HETATM 773 O  O      . HOH L 4 . ? 4.41742  4.41742  0.00000  0.50  14.28590 ? 207 HOH A O      1
+HETATM 774 O  O      . HOH L 4 . ? 1.34664  9.92160  -4.88910 1.000 33.94134 ? 208 HOH A O      1
+HETATM 775 O  O      . HOH L 4 . ? 4.449    3.682    4.274    1.000 18.70128 ? 209 HOH A O      1
+HETATM 776 O  O      . HOH L 4 . ? 0.00000  16.41050 7.55562  0.25  4.45502  ? 210 HOH A O      1
+HETATM 777 O  O      . HOH L 4 . ? -3.843   9.170    -0.676   1.000 12.35001 ? 211 HOH A O      1
+HETATM 778 O  O      A HOH L 4 . ? 5.176    7.537    9.449    0.503 32.66518 ? 212 HOH A O      1
+HETATM 779 O  O      B HOH L 4 . ? 4.943    7.854    10.104   0.497 14.61074 ? 212 HOH A O      1
+HETATM 780 O  O      . HOH L 4 . ? 8.55613  6.52008  5.95199  1.000 26.21066 ? 213 HOH A O      1
+HETATM 781 O  O      . HOH L 4 . ? -1.12803 6.30990  4.65395  1.000 10.39737 ? 214 HOH A O      1
+HETATM 782 O  O      . HOH L 4 . ? 7.573    14.430   5.006    1.000 15.50243 ? 215 HOH A O      1
+HETATM 783 O  O      . HOH L 4 . ? 10.73190 9.92371  3.33808  1.000 35.39403 ? 216 HOH A O      1
+HETATM 784 O  O      . HOH L 4 . ? 8.10680  13.37379 12.66754 1.000 33.35643 ? 217 HOH A O      1
+HETATM 785 O  O      . HOH L 4 . ? 16.41050 16.41050 8.48816  0.50  28.70623 ? 218 HOH A O      1
+HETATM 786 O  O      A HOH L 4 . ? 12.78059 21.15398 11.16035 0.503 20.86322 ? 219 HOH A O      1
+HETATM 787 O  O      B HOH L 4 . ? 12.63665 22.14166 11.66199 0.497 34.62821 ? 219 HOH A O      1
+HETATM 788 O  O      . HOH L 4 . ? 9.87174  9.87174  0.00000  0.50  14.93552 ? 220 HOH A O      1
+HETATM 789 O  O      . HOH L 4 . ? -3.42901 6.31427  3.07849  1.000 27.12831 ? 221 HOH A O      1
+HETATM 790 O  O      . HOH L 4 . ? 12.585   15.778   3.524    1.000 34.43961 ? 222 HOH A O      1
+HETATM 791 O  O      . HOH L 4 . ? 7.45805  12.21827 -3.33206 1.000 21.16235 ? 223 HOH A O      1
+HETATM 792 O  O      . HOH L 4 . ? 5.93154  4.66358  6.48000  1.000 31.31321 ? 224 HOH A O      1
+HETATM 793 O  O      . HOH L 4 . ? 11.071   20.809   8.833    1.000 24.43499 ? 225 HOH A O      1
+HETATM 794 O  O      . HOH L 4 . ? 2.70158  2.70158  0.00000  0.50  32.54103 ? 226 HOH A O      1
+HETATM 795 O  O      . HOH M 4 . ? 11.37870 21.44230 28.98500 0.50  16.37338 ? 201 HOH B O      1
+HETATM 796 O  O      . HOH M 4 . ? 12.06202 21.72273 24.99576 1.000 24.19329 ? 202 HOH B O      1
+HETATM 797 O  O      A HOH M 4 . ? 8.47386  17.33391 26.45660 0.488 15.95106 ? 203 HOH B O      1
+HETATM 798 O  O      B HOH M 4 . ? 8.44991  15.81625 26.73928 0.512 14.46143 ? 203 HOH B O      1
+HETATM 799 O  O      . HOH M 4 . ? 15.33482 13.77372 18.56560 1.000 35.74391 ? 204 HOH B O      1
+HETATM 800 O  O      . HOH M 4 . ? 6.898    13.484   23.605   1.000 15.68856 ? 205 HOH B O      1
+HETATM 801 O  O      . HOH M 4 . ? 7.76026  15.69509 28.91233 1.000 20.98858 ? 206 HOH B O      1
+HETATM 802 O  O      A HOH M 4 . ? 7.68416  25.41858 34.16153 0.502 14.93176 ? 207 HOH B O      1
+HETATM 803 O  O      B HOH M 4 . ? 8.09262  24.41877 34.50150 0.498 15.59800 ? 207 HOH B O      1
+HETATM 804 O  O      . HOH M 4 . ? 7.49741  11.35026 20.45126 1.000 17.60235 ? 208 HOH B O      1
+HETATM 805 O  O      . HOH M 4 . ? 8.03310  19.04520 18.25893 1.000 15.97381 ? 209 HOH B O      1
+HETATM 806 O  O      . HOH M 4 . ? 10.60867 18.07885 27.24480 1.000 28.11789 ? 210 HOH B O      1
+HETATM 807 O  O      . HOH M 4 . ? 6.51323  21.81538 19.30576 1.000 16.53297 ? 211 HOH B O      1
+HETATM 808 O  O      . HOH M 4 . ? 9.64589  22.08737 20.07457 1.000 38.91115 ? 212 HOH B O      1
+HETATM 809 O  O      . HOH M 4 . ? 10.95692 23.51962 22.47994 1.000 29.49196 ? 213 HOH B O      1
+
+loop_
+_atom_site_anisotrop.id
+_atom_site_anisotrop.type_symbol
+_atom_site_anisotrop.pdbx_label_atom_id
+_atom_site_anisotrop.pdbx_label_alt_id
+_atom_site_anisotrop.pdbx_label_comp_id
+_atom_site_anisotrop.pdbx_label_asym_id
+_atom_site_anisotrop.pdbx_label_seq_id
+_atom_site_anisotrop.pdbx_PDB_ins_code
+_atom_site_anisotrop.U[1][1]
+_atom_site_anisotrop.U[2][2]
+_atom_site_anisotrop.U[3][3]
+_atom_site_anisotrop.U[1][2]
+_atom_site_anisotrop.U[1][3]
+_atom_site_anisotrop.U[2][3]
+_atom_site_anisotrop.pdbx_auth_seq_id
+_atom_site_anisotrop.pdbx_auth_comp_id
+_atom_site_anisotrop.pdbx_auth_asym_id
+_atom_site_anisotrop.pdbx_auth_atom_id
+1   O  "O5'" A G  A 1 ? 0.63080 0.65557 0.60518 -0.01680 0.00695  -0.03389 1   G  A "O5'"
+2   O  "O5'" B G  A 1 ? 0.08823 0.16762 0.11864 -0.00095 0.00081  0.00999  1   G  A "O5'"
+3   C  "C5'" A G  A 1 ? 0.55492 0.59618 0.55050 -0.00664 0.01068  -0.03179 1   G  A "C5'"
+4   C  "C5'" B G  A 1 ? 0.10093 0.13530 0.10418 0.00493  -0.02160 0.00034  1   G  A "C5'"
+5   C  "C4'" A G  A 1 ? 0.43745 0.48957 0.46745 0.01231  0.02057  -0.02967 1   G  A "C4'"
+6   C  "C4'" B G  A 1 ? 0.08090 0.14157 0.12349 -0.00134 -0.02677 -0.00708 1   G  A "C4'"
+7   O  "O4'" A G  A 1 ? 0.34635 0.40246 0.41905 0.04617  0.01113  -0.00907 1   G  A "O4'"
+8   O  "O4'" B G  A 1 ? 0.11773 0.11830 0.12836 0.02313  0.00779  -0.00001 1   G  A "O4'"
+9   C  "C3'" A G  A 1 ? 0.37501 0.46391 0.41768 0.00015  0.03491  -0.04145 1   G  A "C3'"
+10  C  "C3'" B G  A 1 ? 0.07924 0.16413 0.13816 0.00043  -0.00603 -0.02465 1   G  A "C3'"
+11  O  "O3'" A G  A 1 ? 0.32104 0.43891 0.38094 -0.01204 0.07890  -0.05485 1   G  A "O3'"
+12  O  "O3'" B G  A 1 ? 0.06521 0.15223 0.16433 -0.00299 -0.02784 -0.01942 1   G  A "O3'"
+13  C  "C2'" A G  A 1 ? 0.34714 0.44828 0.39401 -0.01047 0.02245  -0.03413 1   G  A "C2'"
+14  C  "C2'" B G  A 1 ? 0.11651 0.13780 0.11097 -0.03039 0.00317  -0.02246 1   G  A "C2'"
+15  O  "O2'" A G  A 1 ? 0.38434 0.50980 0.40846 -0.04135 0.00421  -0.05161 1   G  A "O2'"
+16  O  "O2'" B G  A 1 ? 0.11769 0.17862 0.11607 -0.05573 0.00817  -0.03050 1   G  A "O2'"
+17  C  "C1'" A G  A 1 ? 0.29462 0.35215 0.35233 0.02564  0.02687  -0.01114 1   G  A "C1'"
+18  C  "C1'" B G  A 1 ? 0.09490 0.06167 0.08532 -0.01336 0.01334  -0.02303 1   G  A "C1'"
+19  N  N9    A G  A 1 ? 0.18932 0.22294 0.24556 -0.01463 0.02776  0.00403  1   G  A N9
+20  N  N9    B G  A 1 ? 0.06487 0.10011 0.05167 -0.02837 -0.00044 -0.01122 1   G  A N9
+21  C  C8    A G  A 1 ? 0.17817 0.20901 0.21783 -0.00890 0.01103  0.01346  1   G  A C8
+22  C  C8    B G  A 1 ? 0.10103 0.06681 0.05253 0.01128  0.00735  -0.00124 1   G  A C8
+23  N  N7    A G  A 1 ? 0.14490 0.20898 0.18112 -0.01456 -0.00246 -0.00112 1   G  A N7
+24  N  N7    B G  A 1 ? 0.09344 0.07323 0.03617 -0.01945 0.01023  -0.00332 1   G  A N7
+25  C  C5    A G  A 1 ? 0.13065 0.18789 0.13738 -0.00287 0.03480  0.01055  1   G  A C5
+26  C  C5    B G  A 1 ? 0.07724 0.09410 0.03902 0.01463  0.00336  -0.01793 1   G  A C5
+27  C  C6    A G  A 1 ? 0.14023 0.12423 0.09734 0.00218  0.04335  0.01286  1   G  A C6
+28  C  C6    B G  A 1 ? 0.08158 0.11140 0.06224 -0.01226 0.00637  -0.02204 1   G  A C6
+29  O  O6    A G  A 1 ? 0.12265 0.09523 0.08303 -0.00866 0.00445  0.00038  1   G  A O6
+30  O  O6    B G  A 1 ? 0.08108 0.14408 0.08122 -0.01114 0.03429  -0.01614 1   G  A O6
+31  N  N1    A G  A 1 ? 0.14666 0.12457 0.10508 0.03894  0.06590  0.03669  1   G  A N1
+32  N  N1    B G  A 1 ? 0.06487 0.12592 0.08187 -0.00812 -0.02599 -0.03573 1   G  A N1
+33  C  C2    A G  A 1 ? 0.11552 0.11690 0.09855 0.03335  0.05481  0.01124  1   G  A C2
+34  C  C2    B G  A 1 ? 0.11296 0.13751 0.07257 0.01242  -0.02656 -0.04304 1   G  A C2
+35  N  N2    A G  A 1 ? 0.10795 0.11843 0.09408 0.00760  0.00168  0.00609  1   G  A N2
+36  N  N2    B G  A 1 ? 0.09715 0.15064 0.11370 0.01007  -0.00244 -0.02491 1   G  A N2
+37  N  N3    A G  A 1 ? 0.12720 0.14874 0.12978 -0.02583 0.05168  -0.00411 1   G  A N3
+38  N  N3    B G  A 1 ? 0.11395 0.13977 0.06139 0.01966  -0.02502 -0.03007 1   G  A N3
+39  C  C4    A G  A 1 ? 0.15183 0.18226 0.16938 0.01739  0.05041  -0.00060 1   G  A C4
+40  C  C4    B G  A 1 ? 0.10046 0.08411 0.04365 0.01009  0.00195  -0.01542 1   G  A C4
+65  P  P     A U  A 2 ? 0.26182 0.44230 0.34026 0.03166  0.09957  -0.07326 2   U  A P
+66  P  P     B U  A 2 ? 0.09234 0.27568 0.18540 0.02648  -0.02891 -0.08919 2   U  A P
+67  O  OP1   A U  A 2 ? 0.31017 0.45882 0.34729 0.05997  0.09174  -0.06077 2   U  A OP1
+68  O  OP1   B U  A 2 ? 0.12966 0.34864 0.18737 0.03309  -0.02775 -0.05068 2   U  A OP1
+69  O  OP2   A U  A 2 ? 0.24934 0.45231 0.33359 0.03925  0.10158  -0.05998 2   U  A OP2
+70  O  OP2   B U  A 2 ? 0.08938 0.28589 0.21381 -0.01005 -0.01183 -0.08683 2   U  A OP2
+71  O  "O5'" A U  A 2 ? 0.22017 0.38442 0.28927 -0.03144 0.05413  -0.07430 2   U  A "O5'"
+72  O  "O5'" B U  A 2 ? 0.08194 0.26714 0.18104 0.03366  0.00759  -0.04954 2   U  A "O5'"
+73  C  "C5'" A U  A 2 ? 0.15857 0.32029 0.24288 -0.09585 0.00607  -0.08629 2   U  A "C5'"
+74  C  "C5'" B U  A 2 ? 0.09250 0.22712 0.17311 0.06189  -0.00296 -0.04081 2   U  A "C5'"
+75  C  "C4'" A U  A 2 ? 0.13119 0.30323 0.21083 -0.04830 -0.00961 -0.08089 2   U  A "C4'"
+76  C  "C4'" B U  A 2 ? 0.12072 0.24817 0.18382 0.02840  -0.01066 -0.02994 2   U  A "C4'"
+77  O  "O4'" A U  A 2 ? 0.13264 0.32650 0.22784 -0.03662 -0.00523 -0.06956 2   U  A "O4'"
+78  O  "O4'" B U  A 2 ? 0.12100 0.28272 0.20599 0.02528  -0.01386 -0.03248 2   U  A "O4'"
+79  C  "C3'" A U  A 2 ? 0.10802 0.28067 0.19059 -0.03701 -0.00091 -0.06792 2   U  A "C3'"
+80  C  "C3'" B U  A 2 ? 0.07926 0.25046 0.19033 -0.00034 -0.02440 -0.03302 2   U  A "C3'"
+81  O  "O3'" A U  A 2 ? 0.10205 0.23111 0.17712 -0.01239 0.00282  -0.04703 2   U  A "O3'"
+82  O  "O3'" B U  A 2 ? 0.12973 0.22565 0.21149 0.01903  -0.01022 -0.02228 2   U  A "O3'"
+83  C  "C2'" A U  A 2 ? 0.14844 0.29964 0.19616 -0.03578 0.02401  -0.05219 2   U  A "C2'"
+84  C  "C2'" B U  A 2 ? 0.10095 0.27707 0.19993 0.00089  -0.01468 -0.03883 2   U  A "C2'"
+85  O  "O2'" A U  A 2 ? 0.17143 0.29934 0.18027 -0.06998 0.02264  -0.02708 2   U  A "O2'"
+86  O  "O2'" B U  A 2 ? 0.15683 0.28809 0.21551 0.00332  -0.01110 -0.03714 2   U  A "O2'"
+87  C  "C1'" A U  A 2 ? 0.16154 0.33317 0.22837 -0.03192 0.01412  -0.04526 2   U  A "C1'"
+88  C  "C1'" B U  A 2 ? 0.08754 0.28730 0.19922 0.02123  -0.01422 -0.01012 2   U  A "C1'"
+89  N  N1    A U  A 2 ? 0.18249 0.38482 0.25304 0.01551  0.02145  -0.04263 2   U  A N1
+90  N  N1    B U  A 2 ? 0.07235 0.28381 0.20403 0.01532  0.00059  0.00198  2   U  A N1
+91  C  C2    A U  A 2 ? 0.21911 0.41570 0.27276 0.01295  0.02251  -0.03350 2   U  A C2
+92  C  C2    B U  A 2 ? 0.06448 0.25102 0.19753 -0.01485 0.00125  0.00732  2   U  A C2
+93  O  O2    A U  A 2 ? 0.22367 0.41817 0.27453 0.00432  0.02782  -0.03474 2   U  A O2
+94  O  O2    B U  A 2 ? 0.06586 0.24683 0.19618 0.02139  -0.00503 0.01327  2   U  A O2
+95  N  N3    A U  A 2 ? 0.23469 0.44886 0.28180 0.00211  0.00236  -0.03426 2   U  A N3
+96  N  N3    B U  A 2 ? 0.08268 0.32372 0.20982 0.01293  -0.00883 0.01015  2   U  A N3
+97  C  C4    A U  A 2 ? 0.26440 0.47232 0.27554 0.00360  -0.00811 -0.02970 2   U  A C4
+98  C  C4    B U  A 2 ? 0.09405 0.37607 0.20727 0.00125  -0.00103 0.00363  2   U  A C4
+99  O  O4    A U  A 2 ? 0.29346 0.50314 0.27641 -0.01315 -0.02881 -0.01282 2   U  A O4
+100 O  O4    B U  A 2 ? 0.11429 0.43090 0.19879 -0.02760 -0.01357 0.00404  2   U  A O4
+101 C  C5    A U  A 2 ? 0.25370 0.45441 0.26587 0.02898  0.00722  -0.05138 2   U  A C5
+102 C  C5    B U  A 2 ? 0.10243 0.40491 0.21466 0.00695  -0.00670 -0.02233 2   U  A C5
+103 C  C6    A U  A 2 ? 0.22111 0.42750 0.26263 0.04527  0.00866  -0.05321 2   U  A C6
+104 C  C6    B U  A 2 ? 0.09448 0.35638 0.22215 0.03142  0.00029  -0.01984 2   U  A C6
+125 P  P     A G  A 3 ? 0.12329 0.16303 0.15379 -0.00085 0.02206  0.00306  3   G  A P
+126 P  P     B G  A 3 ? 0.13864 0.21682 0.21235 -0.00878 -0.00396 -0.00851 3   G  A P
+127 O  OP1   A G  A 3 ? 0.16610 0.17734 0.16005 0.00280  0.05437  0.02132  3   G  A OP1
+128 O  OP1   B G  A 3 ? 0.19546 0.28053 0.22289 -0.03599 0.03650  0.01792  3   G  A OP1
+129 O  OP2   A G  A 3 ? 0.13452 0.15308 0.15139 0.00186  0.01731  0.02061  3   G  A OP2
+130 O  OP2   B G  A 3 ? 0.20463 0.22546 0.21666 0.01522  0.00551  -0.02982 3   G  A OP2
+131 O  "O5'" A G  A 3 ? 0.10821 0.16725 0.12293 -0.02142 0.00660  -0.03773 3   G  A "O5'"
+132 O  "O5'" B G  A 3 ? 0.12594 0.23689 0.20445 0.00770  -0.00811 -0.03682 3   G  A "O5'"
+133 C  "C5'" A G  A 3 ? 0.12492 0.20696 0.08030 -0.00441 0.00941  -0.01730 3   G  A "C5'"
+134 C  "C5'" B G  A 3 ? 0.14392 0.25432 0.18997 -0.02129 -0.01340 -0.02013 3   G  A "C5'"
+135 C  "C4'" A G  A 3 ? 0.09135 0.18515 0.09178 -0.01921 0.03816  -0.03727 3   G  A "C4'"
+136 C  "C4'" B G  A 3 ? 0.14842 0.20666 0.18247 -0.01666 -0.02067 -0.01201 3   G  A "C4'"
+137 O  "O4'" A G  A 3 ? 0.09446 0.15381 0.09767 0.00480  0.00468  -0.03609 3   G  A "O4'"
+138 O  "O4'" B G  A 3 ? 0.12706 0.18497 0.17197 -0.00619 -0.03542 -0.00789 3   G  A "O4'"
+139 C  "C3'" A G  A 3 ? 0.09270 0.14100 0.09796 0.03709  0.02655  -0.03567 3   G  A "C3'"
+140 C  "C3'" B G  A 3 ? 0.17305 0.21447 0.17667 0.00333  -0.03135 -0.01834 3   G  A "C3'"
+141 O  "O3'" A G  A 3 ? 0.08001 0.13294 0.09176 0.03623  0.01229  -0.02267 3   G  A "O3'"
+142 O  "O3'" B G  A 3 ? 0.18012 0.23238 0.18322 -0.01653 -0.02261 -0.07487 3   G  A "O3'"
+143 C  "C2'" A G  A 3 ? 0.14270 0.09452 0.11348 0.04178  0.00606  -0.03885 3   G  A "C2'"
+144 C  "C2'" B G  A 3 ? 0.18000 0.19940 0.18353 -0.00405 -0.01885 -0.00537 3   G  A "C2'"
+145 O  "O2'" A G  A 3 ? 0.16146 0.11481 0.13740 0.05988  0.00351  -0.01900 3   G  A "O2'"
+146 O  "O2'" B G  A 3 ? 0.19490 0.18925 0.19865 -0.07051 0.02227  -0.00004 3   G  A "O2'"
+147 C  "C1'" A G  A 3 ? 0.11270 0.09979 0.10153 -0.01475 0.00995  -0.02431 3   G  A "C1'"
+148 C  "C1'" B G  A 3 ? 0.12251 0.18867 0.14583 0.02152  -0.03537 -0.00491 3   G  A "C1'"
+149 N  N9    A G  A 3 ? 0.12653 0.10717 0.12454 -0.02147 0.01169  -0.02666 3   G  A N9
+150 N  N9    B G  A 3 ? 0.10275 0.13979 0.09462 0.02926  -0.02285 -0.03603 3   G  A N9
+151 C  C8    A G  A 3 ? 0.14883 0.10370 0.13363 -0.01782 0.00427  -0.03336 3   G  A C8
+152 C  C8    B G  A 3 ? 0.06604 0.14891 0.07961 0.00846  -0.00673 -0.04607 3   G  A C8
+153 N  N7    A G  A 3 ? 0.13077 0.11789 0.13485 -0.02622 0.01843  -0.02094 3   G  A N7
+154 N  N7    B G  A 3 ? 0.07868 0.14473 0.05707 0.04031  -0.01203 -0.03584 3   G  A N7
+155 C  C5    A G  A 3 ? 0.11413 0.12253 0.10894 0.00454  0.02612  0.00776  3   G  A C5
+156 C  C5    B G  A 3 ? 0.08180 0.11576 0.06352 -0.00559 -0.03898 -0.01412 3   G  A C5
+157 C  C6    A G  A 3 ? 0.10336 0.10305 0.07999 -0.00646 -0.00944 0.02272  3   G  A C6
+158 C  C6    B G  A 3 ? 0.05407 0.12924 0.09147 0.01250  -0.00031 -0.04115 3   G  A C6
+159 O  O6    A G  A 3 ? 0.11764 0.08155 0.07481 0.00082  -0.03463 -0.00920 3   G  A O6
+160 O  O6    B G  A 3 ? 0.08005 0.13977 0.12942 0.01856  0.04285  -0.00361 3   G  A O6
+161 N  N1    A G  A 3 ? 0.08960 0.11256 0.08652 -0.00296 -0.00397 0.01750  3   G  A N1
+162 N  N1    B G  A 3 ? 0.10135 0.07913 0.09304 0.02038  0.00002  -0.02293 3   G  A N1
+163 C  C2    A G  A 3 ? 0.09691 0.12220 0.09217 -0.02495 0.02338  0.03195  3   G  A C2
+164 C  C2    B G  A 3 ? 0.09201 0.10617 0.09259 0.02264  -0.02929 -0.03262 3   G  A C2
+165 N  N2    A G  A 3 ? 0.08659 0.12721 0.09543 0.01046  0.03732  0.00469  3   G  A N2
+166 N  N2    B G  A 3 ? 0.10690 0.09845 0.10372 0.02535  -0.04799 -0.04458 3   G  A N2
+167 N  N3    A G  A 3 ? 0.08558 0.11153 0.10410 -0.00630 0.03333  -0.00408 3   G  A N3
+168 N  N3    B G  A 3 ? 0.11289 0.11062 0.09059 0.01128  -0.04984 -0.03337 3   G  A N3
+169 C  C4    A G  A 3 ? 0.09878 0.10553 0.11472 0.00453  0.01816  0.00052  3   G  A C4
+170 C  C4    B G  A 3 ? 0.09904 0.12499 0.07646 0.01463  -0.03960 -0.02381 3   G  A C4
+193 P  P     A U  A 4 ? 0.09287 0.12431 0.09498 0.02114  0.01079  -0.02077 4   U  A P
+194 P  P     B U  A 4 ? 0.22846 0.22867 0.17421 0.00709  0.01173  -0.05807 4   U  A P
+195 O  OP1   A U  A 4 ? 0.12622 0.12592 0.10052 0.04970  0.00237  -0.03008 4   U  A OP1
+196 O  OP1   B U  A 4 ? 0.21322 0.25674 0.14786 0.02027  0.06427  -0.04659 4   U  A OP1
+197 O  OP2   A U  A 4 ? 0.11307 0.14835 0.09833 0.01611  0.00953  0.00000  4   U  A OP2
+198 O  OP2   B U  A 4 ? 0.26083 0.17809 0.19233 0.00622  0.00643  -0.07179 4   U  A OP2
+199 O  "O5'" A U  A 4 ? 0.15127 0.10427 0.07957 0.04172  -0.00140 -0.02585 4   U  A "O5'"
+200 O  "O5'" B U  A 4 ? 0.16424 0.18320 0.17259 -0.05778 0.02460  -0.04545 4   U  A "O5'"
+201 C  "C5'" A U  A 4 ? 0.15745 0.12234 0.09627 0.04919  -0.01995 -0.03044 4   U  A "C5'"
+202 C  "C5'" B U  A 4 ? 0.17114 0.16283 0.17566 0.01015  0.01089  -0.04892 4   U  A "C5'"
+203 C  "C4'" A U  A 4 ? 0.17350 0.07993 0.09764 0.03645  -0.02117 -0.03514 4   U  A "C4'"
+204 C  "C4'" B U  A 4 ? 0.18436 0.17670 0.16452 0.00025  0.01093  -0.01170 4   U  A "C4'"
+205 O  "O4'" A U  A 4 ? 0.13486 0.08599 0.08417 0.02391  0.00901  -0.02647 4   U  A "O4'"
+206 O  "O4'" B U  A 4 ? 0.18211 0.17039 0.14680 0.01481  -0.01438 0.00578  4   U  A "O4'"
+207 C  "C3'" A U  A 4 ? 0.12617 0.07594 0.08924 0.01478  0.01035  -0.02131 4   U  A "C3'"
+208 C  "C3'" B U  A 4 ? 0.18233 0.19222 0.16256 -0.03701 0.02708  -0.02137 4   U  A "C3'"
+209 O  "O3'" A U  A 4 ? 0.13441 0.07921 0.09945 0.01828  0.01271  -0.01363 4   U  A "O3'"
+210 O  "O3'" B U  A 4 ? 0.20199 0.21247 0.17825 -0.06076 0.06745  -0.06417 4   U  A "O3'"
+211 C  "C2'" A U  A 4 ? 0.12336 0.06328 0.08325 0.00612  0.00477  -0.01639 4   U  A "C2'"
+212 C  "C2'" B U  A 4 ? 0.16781 0.16612 0.15457 -0.02893 0.01548  0.01557  4   U  A "C2'"
+213 O  "O2'" A U  A 4 ? 0.17853 0.09964 0.10898 -0.00179 0.00995  -0.01554 4   U  A "O2'"
+214 O  "O2'" B U  A 4 ? 0.16456 0.17284 0.16108 -0.00651 0.05211  -0.01073 4   U  A "O2'"
+215 C  "C1'" A U  A 4 ? 0.13614 0.05947 0.07664 0.01547  -0.00620 -0.00138 4   U  A "C1'"
+216 C  "C1'" B U  A 4 ? 0.16066 0.15621 0.13668 0.01655  0.00161  -0.02643 4   U  A "C1'"
+217 N  N1    A U  A 4 ? 0.11873 0.10433 0.07918 -0.00866 0.00127  0.02893  4   U  A N1
+218 N  N1    B U  A 4 ? 0.15477 0.14915 0.11724 0.02564  0.00182  -0.07316 4   U  A N1
+219 C  C2    A U  A 4 ? 0.12477 0.08412 0.06369 -0.00662 -0.01484 0.01866  4   U  A C2
+220 C  C2    B U  A 4 ? 0.16942 0.16713 0.12761 0.00559  0.03020  -0.05861 4   U  A C2
+221 O  O2    A U  A 4 ? 0.11564 0.10402 0.09460 -0.04075 -0.01759 0.03262  4   U  A O2
+222 O  O2    B U  A 4 ? 0.17007 0.14505 0.15297 0.04252  0.01583  -0.06780 4   U  A O2
+223 N  N3    A U  A 4 ? 0.10305 0.05367 0.05802 0.00947  -0.02326 0.00017  4   U  A N3
+224 N  N3    B U  A 4 ? 0.13613 0.20632 0.14006 -0.02314 0.06082  -0.02063 4   U  A N3
+225 C  C4    A U  A 4 ? 0.11276 0.07744 0.06227 -0.01160 -0.03258 0.01700  4   U  A C4
+226 C  C4    B U  A 4 ? 0.12499 0.16061 0.13843 0.01424  0.05678  -0.03880 4   U  A C4
+227 O  O4    A U  A 4 ? 0.10502 0.06985 0.05722 0.01409  -0.02980 0.00031  4   U  A O4
+228 O  O4    B U  A 4 ? 0.12606 0.20455 0.15907 -0.03692 0.01352  -0.02139 4   U  A O4
+229 C  C5    A U  A 4 ? 0.12250 0.08450 0.08038 -0.00007 -0.03512 0.01294  4   U  A C5
+230 C  C5    B U  A 4 ? 0.11986 0.17891 0.11676 0.02252  0.03514  -0.06002 4   U  A C5
+231 C  C6    A U  A 4 ? 0.14436 0.09088 0.09601 0.01888  -0.00989 0.02035  4   U  A C6
+232 C  C6    B U  A 4 ? 0.12871 0.18106 0.11006 0.01288  0.02791  -0.06750 4   U  A C6
+253 P  P     A G  A 5 ? 0.10901 0.08824 0.09478 0.02446  -0.00091 -0.00941 5   G  A P
+254 P  P     B G  A 5 ? 0.18856 0.24627 0.17215 -0.05614 0.06763  -0.08472 5   G  A P
+255 O  OP1   A G  A 5 ? 0.12498 0.08508 0.10380 0.04398  0.02354  -0.02571 5   G  A OP1
+256 O  OP1   B G  A 5 ? 0.21173 0.26725 0.16354 -0.03481 0.04857  -0.07239 5   G  A OP1
+257 O  OP2   A G  A 5 ? 0.10520 0.10686 0.10583 0.01597  0.02216  0.01955  5   G  A OP2
+258 O  OP2   B G  A 5 ? 0.16788 0.22975 0.18839 -0.02380 0.01925  -0.10127 5   G  A OP2
+259 O  "O5'" A G  A 5 ? 0.10877 0.09540 0.09813 0.04886  0.02108  -0.01587 5   G  A "O5'"
+260 O  "O5'" B G  A 5 ? 0.16849 0.17385 0.19121 -0.08816 0.02098  -0.06372 5   G  A "O5'"
+261 C  "C5'" A G  A 5 ? 0.11720 0.09698 0.11516 0.01273  0.01157  -0.00892 5   G  A "C5'"
+262 C  "C5'" B G  A 5 ? 0.18656 0.17746 0.18986 -0.05333 -0.01958 -0.04705 5   G  A "C5'"
+263 C  "C4'" A G  A 5 ? 0.09934 0.10284 0.12101 0.01254  0.00631  -0.01614 5   G  A "C4'"
+264 C  "C4'" B G  A 5 ? 0.16178 0.16120 0.17527 -0.02042 -0.00610 -0.03755 5   G  A "C4'"
+265 O  "O4'" A G  A 5 ? 0.11908 0.08389 0.12180 -0.00417 -0.00796 -0.03806 5   G  A "O4'"
+266 O  "O4'" B G  A 5 ? 0.11237 0.14496 0.15470 0.01435  0.01294  -0.00372 5   G  A "O4'"
+267 C  "C3'" A G  A 5 ? 0.09993 0.09016 0.12079 0.01296  0.00527  -0.03496 5   G  A "C3'"
+268 C  "C3'" B G  A 5 ? 0.20646 0.16578 0.17964 -0.01926 -0.00317 -0.06308 5   G  A "C3'"
+269 O  "O3'" A G  A 5 ? 0.08453 0.09734 0.11997 0.01257  -0.00583 -0.02214 5   G  A "O3'"
+270 O  "O3'" B G  A 5 ? 0.24512 0.16883 0.18580 -0.02510 -0.00805 -0.06808 5   G  A "O3'"
+271 C  "C2'" A G  A 5 ? 0.10276 0.09165 0.11002 -0.00490 0.00176  -0.02156 5   G  A "C2'"
+272 C  "C2'" B G  A 5 ? 0.19916 0.15848 0.16221 -0.00363 -0.01491 -0.03806 5   G  A "C2'"
+273 O  "O2'" A G  A 5 ? 0.09498 0.09401 0.11145 -0.00441 -0.00412 -0.03699 5   G  A "O2'"
+274 O  "O2'" B G  A 5 ? 0.22894 0.20520 0.16663 -0.03519 -0.01834 -0.08020 5   G  A "O2'"
+275 C  "C1'" A G  A 5 ? 0.09557 0.10428 0.10830 -0.00167 -0.00892 -0.02521 5   G  A "C1'"
+276 C  "C1'" B G  A 5 ? 0.14436 0.14363 0.13433 0.01950  -0.02507 -0.01398 5   G  A "C1'"
+277 N  N9    A G  A 5 ? 0.12056 0.09948 0.10839 0.02839  0.02131  -0.01517 5   G  A N9
+278 N  N9    B G  A 5 ? 0.08795 0.10550 0.09437 -0.00608 -0.02201 -0.02823 5   G  A N9
+279 C  C8    A G  A 5 ? 0.13294 0.09610 0.11422 0.01952  0.05858  -0.00422 5   G  A C8
+280 C  C8    B G  A 5 ? 0.11830 0.09902 0.08741 0.00474  -0.02217 -0.03224 5   G  A C8
+281 N  N7    A G  A 5 ? 0.15067 0.12178 0.12027 0.01598  0.06638  0.00503  5   G  A N7
+282 N  N7    B G  A 5 ? 0.08661 0.10300 0.09425 0.00308  -0.02963 -0.02596 5   G  A N7
+283 C  C5    A G  A 5 ? 0.14850 0.11929 0.11883 0.00448  0.04778  0.02526  5   G  A C5
+284 C  C5    B G  A 5 ? 0.07041 0.10345 0.07252 0.00380  -0.02438 -0.03493 5   G  A C5
+285 C  C6    A G  A 5 ? 0.11219 0.11831 0.11921 0.02510  0.03930  0.00567  5   G  A C6
+286 C  C6    B G  A 5 ? 0.08920 0.08385 0.05405 0.00723  -0.01844 -0.03441 5   G  A C6
+287 O  O6    A G  A 5 ? 0.10053 0.14127 0.12820 0.01612  0.02611  0.00241  5   G  A O6
+288 O  O6    B G  A 5 ? 0.09334 0.05616 0.05586 -0.00339 -0.02376 -0.02049 5   G  A O6
+289 N  N1    A G  A 5 ? 0.14005 0.07704 0.11859 0.00541  0.03626  -0.02514 5   G  A N1
+290 N  N1    B G  A 5 ? 0.08521 0.11057 0.07859 0.00084  -0.04611 0.00160  5   G  A N1
+291 C  C2    A G  A 5 ? 0.13831 0.10864 0.12770 0.00774  0.05944  -0.04067 5   G  A C2
+292 C  C2    B G  A 5 ? 0.08447 0.09674 0.10677 -0.00689 -0.04739 0.00426  5   G  A C2
+293 N  N2    A G  A 5 ? 0.15138 0.09626 0.12729 -0.03026 0.04011  -0.05667 5   G  A N2
+294 N  N2    B G  A 5 ? 0.06737 0.12980 0.12635 0.00489  -0.04111 0.02150  5   G  A N2
+295 N  N3    A G  A 5 ? 0.17465 0.08220 0.12191 0.00480  0.04496  -0.03109 5   G  A N3
+296 N  N3    B G  A 5 ? 0.09380 0.11467 0.09726 0.00694  -0.04942 0.00213  5   G  A N3
+297 C  C4    A G  A 5 ? 0.12569 0.12683 0.10296 0.01700  0.05198  -0.00034 5   G  A C4
+298 C  C4    B G  A 5 ? 0.10861 0.09008 0.09101 -0.00054 -0.05225 -0.00891 5   G  A C4
+321 P  P     A U  A 6 ? 0.10448 0.12969 0.10224 0.02167  -0.00588 -0.04318 6   U  A P
+322 P  P     B U  A 6 ? 0.29135 0.20829 0.19218 -0.02603 -0.01146 -0.06259 6   U  A P
+323 O  OP1   A U  A 6 ? 0.13204 0.17803 0.10244 0.07099  -0.01504 -0.02143 6   U  A OP1
+324 O  OP1   B U  A 6 ? 0.29238 0.19165 0.21622 -0.07898 0.00036  -0.03579 6   U  A OP1
+325 O  OP2   A U  A 6 ? 0.08933 0.18574 0.12318 0.01436  -0.00456 -0.05189 6   U  A OP2
+326 O  OP2   B U  A 6 ? 0.28779 0.19839 0.18487 0.00335  -0.02225 -0.06156 6   U  A OP2
+327 O  "O5'" A U  A 6 ? 0.12244 0.13521 0.09195 0.00367  -0.01766 -0.03187 6   U  A "O5'"
+328 O  "O5'" B U  A 6 ? 0.25215 0.23879 0.16870 -0.00085 0.03658  -0.04971 6   U  A "O5'"
+329 C  "C5'" A U  A 6 ? 0.09764 0.12576 0.10228 0.02530  -0.00176 -0.04249 6   U  A "C5'"
+330 C  "C5'" B U  A 6 ? 0.21603 0.21591 0.16487 0.00466  0.03806  -0.03635 6   U  A "C5'"
+331 C  "C4'" A U  A 6 ? 0.14451 0.10457 0.10351 0.03669  -0.02022 -0.01432 6   U  A "C4'"
+332 C  "C4'" B U  A 6 ? 0.14352 0.16256 0.15029 0.03142  0.03066  -0.02575 6   U  A "C4'"
+333 O  "O4'" A U  A 6 ? 0.13663 0.14106 0.12764 0.04994  -0.00549 -0.02769 6   U  A "O4'"
+334 O  "O4'" B U  A 6 ? 0.13504 0.15115 0.12099 -0.00307 0.01160  -0.03355 6   U  A "O4'"
+335 C  "C3'" A U  A 6 ? 0.09992 0.14738 0.10138 0.01764  0.00362  -0.02500 6   U  A "C3'"
+336 C  "C3'" B U  A 6 ? 0.15332 0.18063 0.14996 0.00622  0.04079  -0.01707 6   U  A "C3'"
+337 O  "O3'" A U  A 6 ? 0.09461 0.15375 0.12458 0.00128  0.00130  -0.06122 6   U  A "O3'"
+338 O  "O3'" B U  A 6 ? 0.15115 0.17693 0.15997 0.04828  0.04524  -0.00364 6   U  A "O3'"
+339 C  "C2'" A U  A 6 ? 0.11533 0.14116 0.10430 0.02983  -0.00949 -0.03684 6   U  A "C2'"
+340 C  "C2'" B U  A 6 ? 0.12282 0.13733 0.12965 0.00599  0.04521  -0.01633 6   U  A "C2'"
+341 O  "O2'" A U  A 6 ? 0.09768 0.17573 0.11270 0.03485  -0.02239 -0.07165 6   U  A "O2'"
+342 O  "O2'" B U  A 6 ? 0.15206 0.10164 0.12930 0.01326  0.04449  0.00819  6   U  A "O2'"
+343 C  "C1'" A U  A 6 ? 0.12858 0.11297 0.11632 0.03471  -0.01700 -0.03805 6   U  A "C1'"
+344 C  "C1'" B U  A 6 ? 0.13941 0.13981 0.12973 0.01355  0.03705  -0.03437 6   U  A "C1'"
+345 N  N1    A U  A 6 ? 0.09572 0.12494 0.09857 0.01127  -0.01326 -0.02656 6   U  A N1
+346 N  N1    B U  A 6 ? 0.13643 0.12832 0.11303 0.00343  0.05068  -0.01435 6   U  A N1
+347 C  C2    A U  A 6 ? 0.09415 0.12578 0.10248 0.03152  -0.00050 -0.02180 6   U  A C2
+348 C  C2    B U  A 6 ? 0.14362 0.11233 0.09542 -0.01786 0.03503  -0.00218 6   U  A C2
+349 O  O2    A U  A 6 ? 0.09714 0.14375 0.12757 0.02117  -0.01362 -0.03833 6   U  A O2
+350 O  O2    B U  A 6 ? 0.11962 0.12231 0.10364 -0.00927 0.03186  0.03088  6   U  A O2
+351 N  N3    A U  A 6 ? 0.08488 0.13559 0.09735 0.01327  0.00200  -0.01674 6   U  A N3
+352 N  N3    B U  A 6 ? 0.12855 0.08040 0.11300 0.01695  0.01209  -0.01722 6   U  A N3
+353 C  C4    A U  A 6 ? 0.10543 0.09436 0.08143 -0.00074 0.01573  -0.03828 6   U  A C4
+354 C  C4    B U  A 6 ? 0.15877 0.08856 0.12326 0.01298  -0.00296 -0.00045 6   U  A C4
+355 O  O4    A U  A 6 ? 0.09539 0.11535 0.07663 -0.00437 0.00298  0.00595  6   U  A O4
+356 O  O4    B U  A 6 ? 0.13691 0.09761 0.13993 0.01086  -0.03005 -0.02341 6   U  A O4
+357 C  C5    A U  A 6 ? 0.10116 0.13568 0.09847 -0.00118 0.02817  -0.04369 6   U  A C5
+358 C  C5    B U  A 6 ? 0.15500 0.11782 0.11279 -0.00253 -0.01718 0.02283  6   U  A C5
+359 C  C6    A U  A 6 ? 0.11699 0.11821 0.10209 0.00320  0.03099  -0.03493 6   U  A C6
+360 C  C6    B U  A 6 ? 0.17414 0.12821 0.11980 0.00371  0.03261  0.00223  6   U  A C6
+379 O  "O5'" A G  B 1 ? 0.23096 0.22420 0.17849 0.08657  -0.01528 0.00326  1   G  B "O5'"
+380 O  "O5'" B G  B 1 ? 0.08289 0.16319 0.17468 -0.02155 0.05623  -0.00540 1   G  B "O5'"
+381 C  "C5'" A G  B 1 ? 0.20622 0.21086 0.14340 0.02785  -0.00937 -0.02739 1   G  B "C5'"
+382 C  "C5'" B G  B 1 ? 0.09783 0.16923 0.16345 0.00626  0.02257  -0.00079 1   G  B "C5'"
+383 C  "C4'" A G  B 1 ? 0.16072 0.19035 0.15044 0.00892  -0.00933 -0.01595 1   G  B "C4'"
+384 C  "C4'" B G  B 1 ? 0.08376 0.15602 0.13986 0.04348  0.00914  -0.00369 1   G  B "C4'"
+385 O  "O4'" A G  B 1 ? 0.16065 0.13294 0.13956 0.01102  0.00708  -0.00751 1   G  B "O4'"
+386 O  "O4'" B G  B 1 ? 0.09891 0.14742 0.12230 0.02509  -0.02274 0.00160  1   G  B "O4'"
+387 C  "C3'" A G  B 1 ? 0.14407 0.19583 0.16077 0.02217  -0.01807 -0.04001 1   G  B "C3'"
+388 C  "C3'" B G  B 1 ? 0.13140 0.15049 0.13267 0.03164  -0.01175 -0.02117 1   G  B "C3'"
+389 O  "O3'" A G  B 1 ? 0.16130 0.22373 0.20257 0.05136  -0.02337 -0.05600 1   G  B "O3'"
+390 O  "O3'" B G  B 1 ? 0.15363 0.15301 0.16238 0.03342  -0.01713 -0.03957 1   G  B "O3'"
+391 C  "C2'" A G  B 1 ? 0.15087 0.18373 0.14749 -0.00857 -0.01172 -0.07675 1   G  B "C2'"
+392 C  "C2'" B G  B 1 ? 0.10139 0.17207 0.10691 0.02682  0.00484  -0.00677 1   G  B "C2'"
+393 O  "O2'" A G  B 1 ? 0.15529 0.18654 0.17085 0.03078  -0.03398 -0.07234 1   G  B "O2'"
+394 O  "O2'" B G  B 1 ? 0.10963 0.22016 0.11520 0.01764  0.00545  -0.04242 1   G  B "O2'"
+395 C  "C1'" A G  B 1 ? 0.14112 0.15867 0.13892 -0.01548 -0.00378 -0.03126 1   G  B "C1'"
+396 C  "C1'" B G  B 1 ? 0.10260 0.13310 0.11125 0.05011  -0.00417 -0.01679 1   G  B "C1'"
+397 N  N9    A G  B 1 ? 0.13337 0.13491 0.11678 -0.00325 0.01336  -0.01047 1   G  B N9
+398 N  N9    B G  B 1 ? 0.10677 0.10917 0.09399 0.00778  -0.02221 -0.00095 1   G  B N9
+399 C  C8    A G  B 1 ? 0.15671 0.11210 0.12462 -0.00071 0.04368  0.00006  1   G  B C8
+400 C  C8    B G  B 1 ? 0.10400 0.10090 0.09832 -0.01616 -0.04807 -0.00936 1   G  B C8
+401 N  N7    A G  B 1 ? 0.11703 0.11767 0.11728 0.02254  0.04883  -0.00619 1   G  B N7
+402 N  N7    B G  B 1 ? 0.10531 0.08867 0.08831 -0.00197 -0.02734 0.01203  1   G  B N7
+403 C  C5    A G  B 1 ? 0.09337 0.14284 0.09752 -0.01443 0.02427  -0.00682 1   G  B C5
+404 C  C5    B G  B 1 ? 0.09911 0.08607 0.07535 -0.00719 -0.01830 0.00286  1   G  B C5
+405 C  C6    A G  B 1 ? 0.08426 0.12315 0.10162 -0.01376 -0.00501 -0.02859 1   G  B C6
+406 C  C6    B G  B 1 ? 0.09242 0.08758 0.07341 -0.01163 -0.01118 0.00952  1   G  B C6
+407 O  O6    A G  B 1 ? 0.08195 0.10526 0.11827 -0.00939 -0.03223 -0.00389 1   G  B O6
+408 O  O6    B G  B 1 ? 0.07481 0.09702 0.08143 -0.01195 0.00141  -0.01934 1   G  B O6
+409 N  N1    A G  B 1 ? 0.09076 0.11656 0.10208 0.04198  -0.00807 -0.05117 1   G  B N1
+410 N  N1    B G  B 1 ? 0.10221 0.08874 0.08027 -0.02500 0.00133  0.01932  1   G  B N1
+411 C  C2    A G  B 1 ? 0.10844 0.14159 0.09345 0.02044  -0.01362 -0.02964 1   G  B C2
+412 C  C2    B G  B 1 ? 0.06577 0.11730 0.08281 -0.03529 -0.00290 0.02044  1   G  B C2
+413 N  N2    A G  B 1 ? 0.09798 0.13955 0.09563 0.00204  0.01955  -0.04827 1   G  B N2
+414 N  N2    B G  B 1 ? 0.06956 0.12044 0.09403 -0.00243 -0.01393 0.02007  1   G  B N2
+415 N  N3    A G  B 1 ? 0.11100 0.12003 0.07619 0.03304  -0.00941 -0.00373 1   G  B N3
+416 N  N3    B G  B 1 ? 0.13941 0.09133 0.08748 -0.01822 0.02725  -0.00283 1   G  B N3
+417 C  C4    A G  B 1 ? 0.11357 0.13809 0.07013 -0.01864 0.00637  -0.00676 1   G  B C4
+418 C  C4    B G  B 1 ? 0.09620 0.11003 0.07616 0.02504  -0.00113 -0.00301 1   G  B C4
+443 P  P     A U  B 2 ? 0.20166 0.30135 0.25080 0.12035  -0.03852 -0.10014 2   U  B P
+444 P  P     B U  B 2 ? 0.14036 0.18845 0.22032 0.02369  0.01979  -0.05992 2   U  B P
+445 O  OP1   A U  B 2 ? 0.28442 0.34313 0.24701 0.07830  -0.02603 -0.09514 2   U  B OP1
+446 O  OP1   B U  B 2 ? 0.17189 0.22489 0.23804 0.02620  0.05481  -0.04707 2   U  B OP1
+447 O  OP2   A U  B 2 ? 0.23597 0.34027 0.26552 0.12429  -0.04832 -0.07761 2   U  B OP2
+448 O  OP2   B U  B 2 ? 0.16462 0.19245 0.22630 0.04957  0.01210  -0.07464 2   U  B OP2
+449 O  "O5'" A U  B 2 ? 0.24730 0.35124 0.28992 0.11843  -0.02491 -0.06115 2   U  B "O5'"
+450 O  "O5'" B U  B 2 ? 0.11914 0.20210 0.24840 -0.00668 0.03597  -0.03068 2   U  B "O5'"
+451 C  "C5'" A U  B 2 ? 0.30840 0.35159 0.31608 0.12269  -0.02485 -0.03534 2   U  B "C5'"
+452 C  "C5'" B U  B 2 ? 0.13567 0.17795 0.26496 0.02940  0.00727  -0.03195 2   U  B "C5'"
+453 C  "C4'" A U  B 2 ? 0.35461 0.38648 0.34368 0.09052  -0.01957 -0.02476 2   U  B "C4'"
+454 C  "C4'" B U  B 2 ? 0.11188 0.19100 0.26291 0.04996  -0.00665 -0.05683 2   U  B "C4'"
+455 O  "O4'" A U  B 2 ? 0.39904 0.43025 0.38144 0.05718  -0.01807 -0.02254 2   U  B "O4'"
+456 O  "O4'" B U  B 2 ? 0.10834 0.21907 0.27265 0.04569  0.00169  -0.06267 2   U  B "O4'"
+457 C  "C3'" A U  B 2 ? 0.35951 0.39398 0.33245 0.05176  -0.01386 -0.02797 2   U  B "C3'"
+458 C  "C3'" B U  B 2 ? 0.11770 0.20220 0.26148 0.02436  -0.02320 -0.08433 2   U  B "C3'"
+459 O  "O3'" A U  B 2 ? 0.28360 0.35863 0.26688 0.05148  -0.00603 -0.00855 2   U  B "O3'"
+460 O  "O3'" B U  B 2 ? 0.12540 0.26106 0.26393 0.07049  -0.02198 -0.08695 2   U  B "O3'"
+461 C  "C2'" A U  B 2 ? 0.41655 0.44164 0.38276 0.03128  -0.01459 -0.03890 2   U  B "C2'"
+462 C  "C2'" B U  B 2 ? 0.11975 0.22105 0.27295 0.00362  0.01383  -0.08421 2   U  B "C2'"
+463 O  "O2'" A U  B 2 ? 0.44663 0.47272 0.40088 0.00822  -0.01375 -0.04693 2   U  B "O2'"
+464 O  "O2'" B U  B 2 ? 0.16222 0.21540 0.28901 -0.00323 0.04265  -0.10464 2   U  B "O2'"
+465 C  "C1'" A U  B 2 ? 0.42442 0.45099 0.41021 0.03792  -0.01562 -0.02988 2   U  B "C1'"
+466 C  "C1'" B U  B 2 ? 0.12246 0.22966 0.27561 0.01674  0.03081  -0.07994 2   U  B "C1'"
+467 N  N1    A U  B 2 ? 0.45729 0.48758 0.46022 0.03239  -0.00923 -0.02673 2   U  B N1
+468 N  N1    B U  B 2 ? 0.14490 0.26822 0.27875 0.02118  0.05088  -0.08068 2   U  B N1
+469 C  C2    A U  B 2 ? 0.48352 0.51865 0.48407 0.04751  -0.00050 -0.02595 2   U  B C2
+470 C  C2    B U  B 2 ? 0.15804 0.30520 0.28703 0.02673  0.04436  -0.07896 2   U  B C2
+471 O  O2    A U  B 2 ? 0.48676 0.53835 0.49091 0.07481  -0.00671 -0.02434 2   U  B O2
+472 O  O2    B U  B 2 ? 0.13155 0.36005 0.29298 0.03167  -0.00697 -0.07870 2   U  B O2
+473 N  N3    A U  B 2 ? 0.50179 0.52070 0.49707 0.02705  0.01360  -0.01685 2   U  B N3
+474 N  N3    B U  B 2 ? 0.16799 0.28758 0.29815 -0.00302 0.08373  -0.05727 2   U  B N3
+475 C  C4    A U  B 2 ? 0.51280 0.51589 0.50181 0.01274  0.02133  -0.01173 2   U  B C4
+476 C  C4    B U  B 2 ? 0.22456 0.28270 0.30039 0.03732  0.10520  -0.04595 2   U  B C4
+477 O  O4    A U  B 2 ? 0.54443 0.52529 0.51057 0.00638  0.03132  -0.00568 2   U  B O4
+478 O  O4    B U  B 2 ? 0.29604 0.29019 0.31654 0.03098  0.11808  -0.03878 2   U  B O4
+479 C  C5    A U  B 2 ? 0.48851 0.50512 0.49472 0.00737  0.00989  -0.01560 2   U  B C5
+480 C  C5    B U  B 2 ? 0.22727 0.25531 0.29496 0.04266  0.06215  -0.05831 2   U  B C5
+481 C  C6    A U  B 2 ? 0.46993 0.49823 0.48089 0.01739  -0.00059 -0.01994 2   U  B C6
+482 C  C6    B U  B 2 ? 0.17758 0.26498 0.28274 0.04427  0.06462  -0.07399 2   U  B C6
+503 P  P     A G  B 3 ? 0.20953 0.30925 0.19931 0.06750  0.00492  0.02783  3   G  B P
+504 P  P     B G  B 3 ? 0.27901 0.36766 0.27889 0.05305  0.00070  -0.05765 3   G  B P
+505 O  OP1   A G  B 3 ? 0.31945 0.37210 0.17970 0.12636  -0.07164 0.01737  3   G  B OP1
+506 O  OP1   B G  B 3 ? 0.35214 0.41107 0.29469 0.07824  -0.02142 -0.04511 3   G  B OP1
+507 O  OP2   A G  B 3 ? 0.27271 0.25648 0.23930 0.09390  0.06938  0.06186  3   G  B OP2
+508 O  OP2   B G  B 3 ? 0.34826 0.35670 0.29845 0.04004  0.03520  0.00461  3   G  B OP2
+509 O  "O5'" A G  B 3 ? 0.15747 0.17920 0.17437 0.07156  0.02867  -0.00123 3   G  B "O5'"
+510 O  "O5'" B G  B 3 ? 0.27654 0.33213 0.27197 0.05521  0.00061  -0.04740 3   G  B "O5'"
+511 C  "C5'" A G  B 3 ? 0.14369 0.20984 0.14614 0.03641  0.03185  -0.03105 3   G  B "C5'"
+512 C  "C5'" B G  B 3 ? 0.26689 0.31597 0.25454 0.03299  -0.00289 -0.04964 3   G  B "C5'"
+513 C  "C4'" A G  B 3 ? 0.09116 0.17836 0.10439 -0.01676 -0.02687 -0.03012 3   G  B "C4'"
+514 C  "C4'" B G  B 3 ? 0.21905 0.28489 0.22599 0.01229  -0.02198 -0.05589 3   G  B "C4'"
+515 O  "O4'" A G  B 3 ? 0.06606 0.17028 0.07582 -0.04612 -0.00286 -0.00977 3   G  B "O4'"
+516 O  "O4'" B G  B 3 ? 0.20823 0.28194 0.19947 0.00931  -0.01259 -0.04551 3   G  B "O4'"
+517 C  "C3'" A G  B 3 ? 0.12573 0.15686 0.13031 -0.01607 -0.00114 0.00949  3   G  B "C3'"
+518 C  "C3'" B G  B 3 ? 0.21326 0.25471 0.22548 -0.02133 -0.01247 -0.06544 3   G  B "C3'"
+519 O  "O3'" A G  B 3 ? 0.09300 0.20882 0.15561 0.00220  -0.00088 -0.01903 3   G  B "O3'"
+520 O  "O3'" B G  B 3 ? 0.13523 0.18923 0.19596 -0.03306 -0.05178 -0.07276 3   G  B "O3'"
+521 C  "C2'" A G  B 3 ? 0.05420 0.12929 0.11709 0.01121  0.00434  0.00345  3   G  B "C2'"
+522 C  "C2'" B G  B 3 ? 0.24944 0.27791 0.22844 0.02663  0.00969  -0.05984 3   G  B "C2'"
+523 O  "O2'" A G  B 3 ? 0.08342 0.15314 0.10642 0.01741  -0.01119 0.00054  3   G  B "O2'"
+524 O  "O2'" B G  B 3 ? 0.31436 0.32866 0.25671 0.05688  0.02722  -0.04202 3   G  B "O2'"
+525 C  "C1'" A G  B 3 ? 0.09073 0.10849 0.12446 -0.01874 -0.02367 0.00307  3   G  B "C1'"
+526 C  "C1'" B G  B 3 ? 0.19139 0.24132 0.20279 0.01608  -0.00012 -0.04684 3   G  B "C1'"
+527 N  N9    A G  B 3 ? 0.10259 0.11296 0.12337 0.00031  -0.06664 0.00696  3   G  B N9
+528 N  N9    B G  B 3 ? 0.06966 0.16775 0.13408 -0.01736 0.02337  -0.05340 3   G  B N9
+529 C  C8    A G  B 3 ? 0.12839 0.11578 0.10540 -0.00580 -0.06406 -0.02073 3   G  B C8
+530 C  C8    B G  B 3 ? 0.09948 0.13732 0.13033 -0.01293 0.03057  -0.04049 3   G  B C8
+531 N  N7    A G  B 3 ? 0.08044 0.13822 0.07785 0.02020  -0.02324 0.02132  3   G  B N7
+532 N  N7    B G  B 3 ? 0.10214 0.11124 0.10647 -0.02267 0.03661  -0.02283 3   G  B N7
+533 C  C5    A G  B 3 ? 0.10993 0.08710 0.06058 -0.00621 -0.03031 0.01425  3   G  B C5
+534 C  C5    B G  B 3 ? 0.10413 0.13236 0.09094 -0.02401 0.03704  -0.02313 3   G  B C5
+535 C  C6    A G  B 3 ? 0.04401 0.08755 0.04075 0.02840  -0.00337 0.01086  3   G  B C6
+536 C  C6    B G  B 3 ? 0.14796 0.15003 0.11320 -0.04310 0.03636  -0.02500 3   G  B C6
+537 O  O6    A G  B 3 ? 0.03334 0.07024 0.04908 0.01133  0.00582  0.00485  3   G  B O6
+538 O  O6    B G  B 3 ? 0.16829 0.16965 0.15465 -0.05349 0.03337  -0.01807 3   G  B O6
+539 N  N1    A G  B 3 ? 0.04167 0.08369 0.04277 0.00089  -0.02115 0.00063  3   G  B N1
+540 N  N1    B G  B 3 ? 0.16097 0.13477 0.11316 0.01093  0.03968  0.02114  3   G  B N1
+541 C  C2    A G  B 3 ? 0.09627 0.12567 0.06317 -0.00365 -0.02993 -0.02701 3   G  B C2
+542 C  C2    B G  B 3 ? 0.09967 0.12327 0.08762 -0.03056 0.02352  0.04098  3   G  B C2
+543 N  N2    A G  B 3 ? 0.07476 0.12416 0.09175 0.00127  -0.01789 -0.03649 3   G  B N2
+544 N  N2    B G  B 3 ? 0.10964 0.11468 0.11452 -0.01614 -0.00037 0.05907  3   G  B N2
+545 N  N3    A G  B 3 ? 0.12652 0.11421 0.11390 0.00553  -0.03457 -0.02390 3   G  B N3
+546 N  N3    B G  B 3 ? 0.05916 0.14613 0.06648 -0.00847 -0.00610 0.01281  3   G  B N3
+547 C  C4    A G  B 3 ? 0.13943 0.08813 0.10333 0.00215  -0.04977 -0.00627 3   G  B C4
+548 C  C4    B G  B 3 ? 0.05778 0.14737 0.08587 -0.02149 0.02745  -0.01095 3   G  B C4
+571 P  P     A U  B 4 ? 0.14029 0.21454 0.17528 0.00139  -0.00842 -0.04573 4   U  B P
+572 P  P     B U  B 4 ? 0.22912 0.22345 0.19480 0.04180  -0.09658 -0.09282 4   U  B P
+573 O  OP1   A U  B 4 ? 0.15315 0.27262 0.19546 -0.01793 0.01445  -0.02003 4   U  B OP1
+574 O  OP1   B U  B 4 ? 0.28124 0.30847 0.24709 0.07035  -0.12873 -0.10667 4   U  B OP1
+575 O  OP2   A U  B 4 ? 0.16304 0.26805 0.16999 0.04559  -0.05127 -0.07894 4   U  B OP2
+576 O  OP2   B U  B 4 ? 0.33111 0.22510 0.17454 0.07046  -0.04044 -0.09655 4   U  B OP2
+577 O  "O5'" A U  B 4 ? 0.12482 0.20745 0.16761 -0.02618 0.00278  -0.02373 4   U  B "O5'"
+578 O  "O5'" B U  B 4 ? 0.18511 0.18832 0.16122 0.02257  -0.05083 -0.07376 4   U  B "O5'"
+579 C  "C5'" A U  B 4 ? 0.13550 0.19281 0.13723 -0.01326 0.02032  -0.02671 4   U  B "C5'"
+580 C  "C5'" B U  B 4 ? 0.12298 0.16008 0.14780 -0.05328 -0.03947 0.00232  4   U  B "C5'"
+581 C  "C4'" A U  B 4 ? 0.08839 0.17199 0.11955 -0.00532 0.00816  -0.03418 4   U  B "C4'"
+582 C  "C4'" B U  B 4 ? 0.12659 0.14223 0.12027 -0.07747 -0.01602 0.01701  4   U  B "C4'"
+583 O  "O4'" A U  B 4 ? 0.11784 0.13172 0.10222 -0.00696 0.02049  -0.00940 4   U  B "O4'"
+584 O  "O4'" B U  B 4 ? 0.12000 0.15638 0.08670 -0.05840 -0.00879 0.01658  4   U  B "O4'"
+585 C  "C3'" A U  B 4 ? 0.10717 0.14854 0.14684 -0.03488 -0.00279 -0.03960 4   U  B "C3'"
+586 C  "C3'" B U  B 4 ? 0.13063 0.13449 0.10981 -0.04643 -0.03828 -0.01542 4   U  B "C3'"
+587 O  "O3'" A U  B 4 ? 0.09999 0.17578 0.16791 -0.02420 -0.02803 -0.05316 4   U  B "O3'"
+588 O  "O3'" B U  B 4 ? 0.14379 0.13970 0.13311 -0.05040 -0.04675 -0.00881 4   U  B "O3'"
+589 C  "C2'" A U  B 4 ? 0.09908 0.13403 0.14201 -0.03786 0.02399  -0.05645 4   U  B "C2'"
+590 C  "C2'" B U  B 4 ? 0.11801 0.16342 0.12348 -0.05936 -0.02828 0.03301  4   U  B "C2'"
+591 O  "O2'" A U  B 4 ? 0.12049 0.14948 0.17821 -0.03553 0.02606  -0.03914 4   U  B "O2'"
+592 O  "O2'" B U  B 4 ? 0.14736 0.18445 0.16738 -0.03517 -0.04701 0.01018  4   U  B "O2'"
+593 C  "C1'" A U  B 4 ? 0.11535 0.12686 0.10702 -0.02401 0.00493  -0.03160 4   U  B "C1'"
+594 C  "C1'" B U  B 4 ? 0.13431 0.12415 0.11555 -0.05193 -0.01383 0.02104  4   U  B "C1'"
+595 N  N1    A U  B 4 ? 0.07269 0.11895 0.08298 -0.02113 -0.02634 -0.02918 4   U  B N1
+596 N  N1    B U  B 4 ? 0.13721 0.15567 0.12810 -0.03223 0.02046  0.02714  4   U  B N1
+597 C  C2    A U  B 4 ? 0.10036 0.07941 0.07480 -0.00349 -0.03390 -0.02218 4   U  B C2
+598 C  C2    B U  B 4 ? 0.15146 0.14166 0.12721 -0.03997 0.04838  0.02985  4   U  B C2
+599 O  O2    A U  B 4 ? 0.10230 0.09286 0.11172 -0.01148 -0.03900 -0.01491 4   U  B O2
+600 O  O2    B U  B 4 ? 0.16156 0.11800 0.14612 -0.03795 0.01523  0.02708  4   U  B O2
+601 N  N3    A U  B 4 ? 0.07383 0.08308 0.08327 0.01117  -0.04416 0.00524  4   U  B N3
+602 N  N3    B U  B 4 ? 0.12008 0.12365 0.12821 -0.04415 0.06064  -0.00414 4   U  B N3
+603 C  C4    A U  B 4 ? 0.07424 0.08701 0.07921 -0.01532 -0.04416 0.00881  4   U  B C4
+604 C  C4    B U  B 4 ? 0.10955 0.13662 0.11812 0.00718  0.06743  0.01092  4   U  B C4
+605 O  O4    A U  B 4 ? 0.07748 0.06837 0.09799 -0.01285 -0.04030 0.01055  4   U  B O4
+606 O  O4    B U  B 4 ? 0.10307 0.12547 0.12384 0.00774  0.06677  0.00927  4   U  B O4
+607 C  C5    A U  B 4 ? 0.07113 0.11381 0.07270 -0.00746 -0.02868 -0.00842 4   U  B C5
+608 C  C5    B U  B 4 ? 0.08875 0.16684 0.12005 0.00304  0.06055  -0.00235 4   U  B C5
+609 C  C6    A U  B 4 ? 0.05730 0.12465 0.07475 0.01183  -0.03024 -0.01999 4   U  B C6
+610 C  C6    B U  B 4 ? 0.13315 0.18650 0.11525 -0.05198 0.04892  0.02079  4   U  B C6
+631 P  P     A G  B 5 ? 0.12886 0.18602 0.15156 -0.02243 -0.01453 -0.05859 5   G  B P
+632 P  P     B G  B 5 ? 0.09747 0.12071 0.13798 -0.02325 -0.03181 -0.02216 5   G  B P
+633 O  OP1   A G  B 5 ? 0.13589 0.16980 0.16727 -0.02229 0.00138  -0.02772 5   G  B OP1
+634 O  OP1   B G  B 5 ? 0.09618 0.13216 0.14184 -0.02366 -0.03745 -0.02634 5   G  B OP1
+635 O  OP2   A G  B 5 ? 0.14528 0.17416 0.16032 0.00782  -0.02746 -0.06445 5   G  B OP2
+636 O  OP2   B G  B 5 ? 0.12225 0.12949 0.13154 -0.01237 -0.00689 -0.02464 5   G  B OP2
+637 O  "O5'" A G  B 5 ? 0.12886 0.15556 0.16950 -0.03389 -0.00373 -0.07363 5   G  B "O5'"
+638 O  "O5'" B G  B 5 ? 0.13052 0.10305 0.13980 -0.01270 -0.03322 -0.02705 5   G  B "O5'"
+639 C  "C5'" A G  B 5 ? 0.11496 0.16277 0.19735 -0.02587 -0.00245 -0.05439 5   G  B "C5'"
+640 C  "C5'" B G  B 5 ? 0.14668 0.12705 0.17955 -0.05260 -0.02237 -0.03627 5   G  B "C5'"
+641 C  "C4'" A G  B 5 ? 0.10047 0.13522 0.17828 -0.02943 -0.00024 -0.01731 5   G  B "C4'"
+642 C  "C4'" B G  B 5 ? 0.12392 0.12449 0.16952 -0.03568 -0.02661 -0.04567 5   G  B "C4'"
+643 O  "O4'" A G  B 5 ? 0.11531 0.10307 0.17647 -0.00487 -0.01495 -0.02596 5   G  B "O4'"
+644 O  "O4'" B G  B 5 ? 0.12150 0.10439 0.17245 -0.05113 -0.01873 -0.01605 5   G  B "O4'"
+645 C  "C3'" A G  B 5 ? 0.14064 0.12696 0.17535 -0.03391 -0.03441 -0.04839 5   G  B "C3'"
+646 C  "C3'" B G  B 5 ? 0.10434 0.10555 0.17091 -0.01138 -0.03294 -0.06191 5   G  B "C3'"
+647 O  "O3'" A G  B 5 ? 0.16625 0.11249 0.17905 -0.01673 -0.01071 -0.03338 5   G  B "O3'"
+648 O  "O3'" B G  B 5 ? 0.13904 0.11650 0.19410 -0.04397 -0.04012 -0.02166 5   G  B "O3'"
+649 C  "C2'" A G  B 5 ? 0.14710 0.10946 0.19174 0.02493  -0.01715 -0.05612 5   G  B "C2'"
+650 C  "C2'" B G  B 5 ? 0.12282 0.11959 0.17307 -0.03366 -0.02114 -0.06410 5   G  B "C2'"
+651 O  "O2'" A G  B 5 ? 0.21580 0.10222 0.23186 0.03223  -0.02736 -0.06775 5   G  B "O2'"
+652 O  "O2'" B G  B 5 ? 0.15503 0.13690 0.21587 0.00000  -0.04542 -0.08877 5   G  B "O2'"
+653 C  "C1'" A G  B 5 ? 0.10825 0.07370 0.16617 -0.00681 -0.03325 -0.03241 5   G  B "C1'"
+654 C  "C1'" B G  B 5 ? 0.13608 0.07619 0.15260 -0.01173 -0.01380 -0.03330 5   G  B "C1'"
+655 N  N9    A G  B 5 ? 0.09050 0.10507 0.13793 -0.00920 -0.00835 0.01781  5   G  B N9
+656 N  N9    B G  B 5 ? 0.09593 0.09454 0.10899 -0.01706 -0.01919 -0.04076 5   G  B N9
+657 C  C8    A G  B 5 ? 0.08851 0.11503 0.14413 -0.01087 -0.01384 0.01031  5   G  B C8
+658 C  C8    B G  B 5 ? 0.08861 0.09851 0.09642 -0.03010 -0.02652 -0.03521 5   G  B C8
+659 N  N7    A G  B 5 ? 0.11121 0.10017 0.12161 -0.01645 0.03126  -0.01084 5   G  B N7
+660 N  N7    B G  B 5 ? 0.07504 0.08549 0.09764 -0.00497 -0.04639 -0.01699 5   G  B N7
+661 C  C5    A G  B 5 ? 0.10573 0.09955 0.09514 -0.00174 0.00318  -0.02606 5   G  B C5
+662 C  C5    B G  B 5 ? 0.07753 0.09290 0.09360 -0.01428 -0.00361 0.00599  5   G  B C5
+663 C  C6    A G  B 5 ? 0.07351 0.10326 0.08445 -0.00099 -0.01895 -0.04988 5   G  B C6
+664 C  C6    B G  B 5 ? 0.08725 0.10779 0.09170 -0.01052 0.02582  0.04351  5   G  B C6
+665 O  O6    A G  B 5 ? 0.08794 0.05515 0.07554 0.00530  0.00373  -0.03730 5   G  B O6
+666 O  O6    B G  B 5 ? 0.05878 0.12620 0.10108 -0.02279 -0.00047 0.03280  5   G  B O6
+667 N  N1    A G  B 5 ? 0.08272 0.07041 0.10267 -0.00892 -0.04861 -0.01430 5   G  B N1
+668 N  N1    B G  B 5 ? 0.09310 0.07264 0.10570 0.00326  0.05874  0.00295  5   G  B N1
+669 C  C2    A G  B 5 ? 0.10492 0.08743 0.10441 -0.00930 -0.06111 0.00788  5   G  B C2
+670 C  C2    B G  B 5 ? 0.10049 0.07711 0.11461 -0.00079 0.05093  -0.01661 5   G  B C2
+671 N  N2    A G  B 5 ? 0.13431 0.09016 0.13659 0.00464  -0.04747 0.01784  5   G  B N2
+672 N  N2    B G  B 5 ? 0.08468 0.08107 0.13415 0.00550  0.02550  -0.04299 5   G  B N2
+673 N  N3    A G  B 5 ? 0.11473 0.09504 0.11810 0.00188  -0.03646 -0.01089 5   G  B N3
+674 N  N3    B G  B 5 ? 0.10097 0.06193 0.11487 -0.00578 0.02907  -0.01627 5   G  B N3
+675 C  C4    A G  B 5 ? 0.11003 0.11280 0.10702 -0.00688 -0.01512 0.00665  5   G  B C4
+676 C  C4    B G  B 5 ? 0.10512 0.07201 0.09395 0.00513  0.01240  -0.03093 5   G  B C4
+699 P  P     A U  B 6 ? 0.14586 0.12257 0.18430 -0.00507 -0.02353 -0.04911 6   U  B P
+700 P  P     B U  B 6 ? 0.16294 0.15557 0.21025 -0.03245 -0.07947 -0.02616 6   U  B P
+701 O  OP1   A U  B 6 ? 0.12922 0.15920 0.17435 -0.01799 -0.01219 -0.04748 6   U  B OP1
+702 O  OP1   B U  B 6 ? 0.17051 0.15034 0.22309 -0.02421 -0.06628 -0.02798 6   U  B OP1
+703 O  OP2   A U  B 6 ? 0.16722 0.15755 0.17149 -0.01547 -0.04388 -0.04403 6   U  B OP2
+704 O  OP2   B U  B 6 ? 0.22674 0.17868 0.19063 -0.03383 -0.08365 -0.06345 6   U  B OP2
+705 O  "O5'" A U  B 6 ? 0.15320 0.14337 0.19463 0.00656  -0.06125 -0.04294 6   U  B "O5'"
+706 O  "O5'" B U  B 6 ? 0.18109 0.18381 0.21179 -0.02756 -0.09509 -0.02455 6   U  B "O5'"
+707 C  "C5'" A U  B 6 ? 0.13864 0.16649 0.18904 0.01445  -0.06907 -0.04972 6   U  B "C5'"
+708 C  "C5'" B U  B 6 ? 0.19248 0.22017 0.22741 -0.04883 -0.09186 -0.01775 6   U  B "C5'"
+709 C  "C4'" A U  B 6 ? 0.13497 0.15706 0.15311 -0.00075 -0.07546 -0.03148 6   U  B "C4'"
+710 C  "C4'" B U  B 6 ? 0.14393 0.20402 0.23015 -0.06311 -0.06854 -0.00172 6   U  B "C4'"
+711 O  "O4'" A U  B 6 ? 0.11383 0.18010 0.14498 0.01375  -0.05830 -0.04418 6   U  B "O4'"
+712 O  "O4'" B U  B 6 ? 0.14420 0.19187 0.20834 -0.01580 -0.07899 0.00392  6   U  B "O4'"
+713 C  "C3'" A U  B 6 ? 0.08814 0.20230 0.16775 0.00599  -0.04993 -0.02803 6   U  B "C3'"
+714 C  "C3'" B U  B 6 ? 0.15661 0.20499 0.24110 -0.05523 -0.03976 -0.00762 6   U  B "C3'"
+715 O  "O3'" A U  B 6 ? 0.11178 0.20024 0.19880 -0.02562 -0.04819 -0.02966 6   U  B "O3'"
+716 O  "O3'" B U  B 6 ? 0.16804 0.25225 0.25204 -0.02738 -0.03929 0.03973  6   U  B "O3'"
+717 C  "C2'" A U  B 6 ? 0.10623 0.14517 0.16257 -0.00125 -0.02221 -0.05199 6   U  B "C2'"
+718 C  "C2'" B U  B 6 ? 0.13075 0.18370 0.21522 -0.02940 -0.00397 0.00223  6   U  B "C2'"
+719 O  "O2'" A U  B 6 ? 0.14008 0.14131 0.19324 -0.00200 -0.00079 -0.05353 6   U  B "O2'"
+720 O  "O2'" B U  B 6 ? 0.11818 0.17558 0.22293 -0.01134 0.01559  -0.00994 6   U  B "O2'"
+721 C  "C1'" A U  B 6 ? 0.11636 0.14376 0.12829 0.00445  -0.04021 -0.02950 6   U  B "C1'"
+722 C  "C1'" B U  B 6 ? 0.13342 0.16334 0.18275 -0.01456 -0.05335 0.00673  6   U  B "C1'"
+723 N  N1    A U  B 6 ? 0.09003 0.15504 0.10392 -0.00513 -0.03354 -0.03341 6   U  B N1
+724 N  N1    B U  B 6 ? 0.10959 0.11662 0.14445 0.00313  -0.03985 0.01191  6   U  B N1
+725 C  C2    A U  B 6 ? 0.09858 0.12607 0.11371 0.00241  -0.01447 -0.04169 6   U  B C2
+726 C  C2    B U  B 6 ? 0.08497 0.11327 0.12010 0.00372  -0.01974 0.04053  6   U  B C2
+727 O  O2    A U  B 6 ? 0.09481 0.12120 0.12750 0.00581  -0.03600 -0.01292 6   U  B O2
+728 O  O2    B U  B 6 ? 0.10542 0.13755 0.11502 0.02545  -0.00040 0.01795  6   U  B O2
+729 N  N3    A U  B 6 ? 0.09900 0.10125 0.11527 -0.02411 -0.03626 -0.03932 6   U  B N3
+730 N  N3    B U  B 6 ? 0.07201 0.08671 0.11058 0.01004  -0.00231 0.02877  6   U  B N3
+731 C  C4    A U  B 6 ? 0.11335 0.09357 0.08844 0.00255  -0.02212 -0.04038 6   U  B C4
+732 C  C4    B U  B 6 ? 0.09414 0.10547 0.08820 -0.01757 -0.00618 0.02474  6   U  B C4
+733 O  O4    A U  B 6 ? 0.10103 0.09769 0.08836 -0.00568 -0.03247 -0.01836 6   U  B O4
+734 O  O4    B U  B 6 ? 0.09797 0.11011 0.08656 -0.01766 -0.00316 0.00195  6   U  B O4
+735 C  C5    A U  B 6 ? 0.10916 0.10923 0.10696 0.00726  -0.00359 -0.02298 6   U  B C5
+736 C  C5    B U  B 6 ? 0.11108 0.09179 0.11067 -0.01495 -0.02078 0.01641  6   U  B C5
+737 C  C6    A U  B 6 ? 0.10127 0.12051 0.11303 -0.00122 -0.01016 -0.02709 6   U  B C6
+738 C  C6    B U  B 6 ? 0.08590 0.13231 0.13419 -0.01847 -0.02896 0.01131  6   U  B C6
+758 K  K     . K  C . ? 0.09614 0.09614 0.08622 0.00000  0.00000  -0.00000 101 K  A K
+759 K  K     . K  D . ? 0.09956 0.09956 0.10729 0.00000  0.00000  -0.00000 102 K  A K
+760 K  K     . K  E . ? 0.10494 0.10494 0.11817 0.00000  0.00000  -0.00000 103 K  A K
+761 K  K     . K  F . ? 0.11028 0.11028 0.11201 0.00000  0.00000  -0.00000 104 K  A K
+762 NA NA    . NA G . ? 0.13676 0.14559 0.13962 0.00884  0.01513  -0.02601 105 NA A NA
+763 K  K     . K  H . ? 0.07789 0.07789 0.08504 0.00000  0.00000  -0.00000 101 K  B K
+764 K  K     . K  I . ? 0.07446 0.07446 0.08667 0.00000  0.00000  -0.00000 102 K  B K
+765 K  K     . K  J . ? 0.08995 0.08995 0.09979 0.00000  0.00000  -0.00000 103 K  B K
+766 NA NA    . NA K . ? 0.19372 0.29730 0.36855 0.02333  -0.02968 0.03215  104 NA B NA
+
+_ndb_struct_ntc_overall.entry_id  8VJT
+_ndb_struct_ntc_overall.confal_score 34.2
+_ndb_struct_ntc_overall.confal_percentile 27
+_ndb_struct_ntc_overall.ntc_version 3.5
+_ndb_struct_ntc_overall.cana_version 2.3
+_ndb_struct_ntc_overall.num_steps 20
+_ndb_struct_ntc_overall.num_classified 12
+_ndb_struct_ntc_overall.num_unclassified 8
+_ndb_struct_ntc_overall.num_unclassified_rmsd_close 0
+
+loop_
+_ndb_struct_ntc_step.id
+_ndb_struct_ntc_step.name
+_ndb_struct_ntc_step.PDB_model_number
+_ndb_struct_ntc_step.label_entity_id_1
+_ndb_struct_ntc_step.label_asym_id_1
+_ndb_struct_ntc_step.label_seq_id_1
+_ndb_struct_ntc_step.label_comp_id_1
+_ndb_struct_ntc_step.label_alt_id_1
+_ndb_struct_ntc_step.label_entity_id_2
+_ndb_struct_ntc_step.label_asym_id_2
+_ndb_struct_ntc_step.label_seq_id_2
+_ndb_struct_ntc_step.label_comp_id_2
+_ndb_struct_ntc_step.label_alt_id_2
+_ndb_struct_ntc_step.auth_asym_id_1
+_ndb_struct_ntc_step.auth_seq_id_1
+_ndb_struct_ntc_step.auth_asym_id_2
+_ndb_struct_ntc_step.auth_seq_id_2
+_ndb_struct_ntc_step.PDB_ins_code_1
+_ndb_struct_ntc_step.PDB_ins_code_2
+1  8vjt_A_G.A_1_U.A_2 1 1 A 1 G A 1 A 2 U A A 1 A 2 . .
+2  8vjt_A_G.B_1_U.B_2 1 1 A 1 G B 1 A 2 U B A 1 A 2 . .
+3  8vjt_A_U.A_2_G.A_3 1 1 A 2 U A 1 A 3 G A A 2 A 3 . .
+4  8vjt_A_U.B_2_G.B_3 1 1 A 2 U B 1 A 3 G B A 2 A 3 . .
+5  8vjt_A_G.A_3_U.A_4 1 1 A 3 G A 1 A 4 U A A 3 A 4 . .
+6  8vjt_A_G.B_3_U.B_4 1 1 A 3 G B 1 A 4 U B A 3 A 4 . .
+7  8vjt_A_U.A_4_G.A_5 1 1 A 4 U A 1 A 5 G A A 4 A 5 . .
+8  8vjt_A_U.B_4_G.B_5 1 1 A 4 U B 1 A 5 G B A 4 A 5 . .
+9  8vjt_A_G.A_5_U.A_6 1 1 A 5 G A 1 A 6 U A A 5 A 6 . .
+10 8vjt_A_G.B_5_U.B_6 1 1 A 5 G B 1 A 6 U B A 5 A 6 . .
+11 8vjt_B_G.A_1_U.A_2 1 1 B 1 G A 1 B 2 U A B 1 B 2 . .
+12 8vjt_B_G.B_1_U.B_2 1 1 B 1 G B 1 B 2 U B B 1 B 2 . .
+13 8vjt_B_U.A_2_G.A_3 1 1 B 2 U A 1 B 3 G A B 2 B 3 . .
+14 8vjt_B_U.B_2_G.B_3 1 1 B 2 U B 1 B 3 G B B 2 B 3 . .
+15 8vjt_B_G.A_3_U.A_4 1 1 B 3 G A 1 B 4 U A B 3 B 4 . .
+16 8vjt_B_G.B_3_U.B_4 1 1 B 3 G B 1 B 4 U B B 3 B 4 . .
+17 8vjt_B_U.A_4_G.A_5 1 1 B 4 U A 1 B 5 G A B 4 B 5 . .
+18 8vjt_B_U.B_4_G.B_5 1 1 B 4 U B 1 B 5 G B B 4 B 5 . .
+19 8vjt_B_G.A_5_U.A_6 1 1 B 5 G A 1 B 6 U A B 5 B 6 . .
+20 8vjt_B_G.B_5_U.B_6 1 1 B 5 G B 1 B 6 U B B 5 B 6 . .
+
+loop_
+_ndb_struct_ntc_step_summary.step_id
+_ndb_struct_ntc_step_summary.assigned_CANA
+_ndb_struct_ntc_step_summary.assigned_NtC
+_ndb_struct_ntc_step_summary.confal_score
+_ndb_struct_ntc_step_summary.euclidean_distance_NtC_ideal
+_ndb_struct_ntc_step_summary.cartesian_rmsd_closest_NtC_representative
+_ndb_struct_ntc_step_summary.closest_CANA
+_ndb_struct_ntc_step_summary.closest_NtC
+_ndb_struct_ntc_step_summary.closest_step_golden
+1  NAN NANT 0  149.1 0.872 OPN OP21 1vq8_0_A_1875_C_1876
+2  NAN NANT 0  160.0 0.790 OPN OP21 1vq8_0_A_1875_C_1876
+3  NAN NANT 0  130.9 1.124 OPN OP17 1vy5_DA_G_2067_U_2068
+4  NAN NANT 0  155.4 1.249 OPN OP17 1vy5_DA_G_2067_U_2068
+5  AAA AA00 15 54.5  0.460 AAA AA00 1xux_A_DG_3_DT_4
+6  AAA AA00 53 36.8  0.302 AAA AA00 369d_A_DG_4_DC_5
+7  AAA AA00 56 34.2  0.354 AAA AA00 1m77_A_DT_6_DC_7
+8  AAA AA08 82 29.5  0.323 AAA AA08 2r8s_R_U_155_U_156
+9  ZZZ ZZ01 77 27.4  0.174 ZZZ ZZ01 4lnt_RA_G_1125_A_1126
+10 ZZZ ZZ01 67 30.2  0.224 ZZZ ZZ01 4u4r_5_C_3367_U_3368
+11 NAN NANT 0  180.8 0.570 OPN OP21 1vq8_0_A_1875_C_1876
+12 NAN NANT 0  170.7 0.564 OPN OP21 1vq8_0_A_1875_C_1876
+13 NAN NANT 0  84.5  0.817 OPN OP20 294d_C_DA_21_DC_22
+14 OPN OP20 3  76.0  0.752 OPN OP20 294d_C_DA_21_DC_22
+15 B-A BA16 63 43.7  0.361 B-A BA16 3ibk_A_G_9_G_10
+16 NAN NANT 0  70.3  0.578 B-A BA08 1qn4_C_DC_202_DT_203
+17 AAA AA08 68 31.6  0.367 AAA AA08 4ybb_AA_G_524_C_525
+18 AAA AA08 67 39.1  0.393 AAA AA08 4w2f_BA_G_760_U_761
+19 ZZZ ZZ01 61 33.8  0.206 ZZZ ZZ01 4lnt_YA_G_1125_A_1126
+20 ZZZ ZZ01 73 28.4  0.176 ZZZ ZZ01 4lnt_YA_G_1125_A_1126
+
+loop_
+_ndb_struct_ntc_step_parameters.step_id
+_ndb_struct_ntc_step_parameters.tor_delta_1
+_ndb_struct_ntc_step_parameters.tor_epsilon_1
+_ndb_struct_ntc_step_parameters.tor_zeta_1
+_ndb_struct_ntc_step_parameters.tor_alpha_2
+_ndb_struct_ntc_step_parameters.tor_beta_2
+_ndb_struct_ntc_step_parameters.tor_gamma_2
+_ndb_struct_ntc_step_parameters.tor_delta_2
+_ndb_struct_ntc_step_parameters.tor_chi_1
+_ndb_struct_ntc_step_parameters.tor_chi_2
+_ndb_struct_ntc_step_parameters.dist_NN
+_ndb_struct_ntc_step_parameters.dist_CC
+_ndb_struct_ntc_step_parameters.tor_NCCN
+_ndb_struct_ntc_step_parameters.diff_tor_delta_1
+_ndb_struct_ntc_step_parameters.diff_tor_epsilon_1
+_ndb_struct_ntc_step_parameters.diff_tor_zeta_1
+_ndb_struct_ntc_step_parameters.diff_tor_alpha_2
+_ndb_struct_ntc_step_parameters.diff_tor_beta_2
+_ndb_struct_ntc_step_parameters.diff_tor_gamma_2
+_ndb_struct_ntc_step_parameters.diff_tor_delta_2
+_ndb_struct_ntc_step_parameters.diff_tor_chi_1
+_ndb_struct_ntc_step_parameters.diff_tor_chi_2
+_ndb_struct_ntc_step_parameters.diff_dist_NN
+_ndb_struct_ntc_step_parameters.diff_dist_CC
+_ndb_struct_ntc_step_parameters.diff_tor_NCCN
+_ndb_struct_ntc_step_parameters.confal_tor_delta_1
+_ndb_struct_ntc_step_parameters.confal_tor_epsilon_1
+_ndb_struct_ntc_step_parameters.confal_tor_zeta_1
+_ndb_struct_ntc_step_parameters.confal_tor_alpha_2
+_ndb_struct_ntc_step_parameters.confal_tor_beta_2
+_ndb_struct_ntc_step_parameters.confal_tor_gamma_2
+_ndb_struct_ntc_step_parameters.confal_tor_delta_2
+_ndb_struct_ntc_step_parameters.confal_tor_chi_1
+_ndb_struct_ntc_step_parameters.confal_tor_chi_2
+_ndb_struct_ntc_step_parameters.confal_dist_NN
+_ndb_struct_ntc_step_parameters.confal_dist_CC
+_ndb_struct_ntc_step_parameters.confal_tor_NCCN
+_ndb_struct_ntc_step_parameters.details
+1  150.0 218.5 66.3  40.0  187.3 64.4  144.6 85.3  257.7 10.17 8.29 250.2 0.6  -23.7 -13.2 -26.7  9.8   1.9   0.7   -142.9 13.8  -0.09 0.06  5.6   99.7  11.2 54.6 17.3 53.2 99.0  99.8 0.0  56.4  96.1  94.5 92.3 cAna2;cAnch1;cNna2;cNnch1
+2  152.9 233.6 52.1  69.7  170.3 54.0  150.0 72.1  255.9 10.28 8.40 250.8 3.5  -8.6  -27.4 3.0    -7.2  -8.5  6.0   -156.1 12.0  0.01  0.17  6.2   90.8  74.7 7.3  97.8 71.4 82.7  87.6 0.0  64.7  99.9  62.1 90.7 cAnz1;cAnch1;cNnz1;cNnch1
+3  144.6 247.0 282.2 193.5 173.5 182.1 87.7  257.7 172.7 9.93  8.41 124.3 -0.6 -19.6 -11.5 -97.5  35.8  4.7   3.9   23.8   -22.2 -0.17 0.54  -66.4 96.0  24.4 65.9 0.0  4.5  93.1  48.5 5.7  9.6   93.0  45.2 0.0  cAna2;cNna2
+4  150.0 256.4 283.3 168.7 170.8 197.6 82.2  255.9 180.5 10.39 8.72 113.5 4.8  -10.2 -10.5 -122.3 33.1  20.2  -1.6  22.0   -14.4 0.28  0.84  -77.1 5.9   68.1 71.0 0.0  7.0  26.9  88.8 8.6  37.6  82.4  14.1 0.0  cAna2;cNna2
+5  87.7  219.8 294.1 295.2 192.1 55.7  83.0  172.7 205.7 5.64  6.35 21.3  5.6  13.6  6.2   1.8    19.5  0.8   1.2   -26.0  5.3   0.87  0.90  3.0   77.0  51.4 81.7 98.2 15.5 99.7  98.6 5.9  87.7  6.6   3.0  93.1 .
+6  82.2  218.7 285.3 308.6 177.6 51.1  82.2  180.5 201.2 5.31  5.97 22.1  0.2  12.5  -2.6  15.1   5.1   -3.9  0.4   -18.1  0.7   0.54  0.52  3.8   100.0 57.0 96.6 26.9 88.2 92.3  99.9 25.0 99.8  34.9  31.4 89.3 .
+7  83.0  223.5 275.1 287.6 168.1 47.8  82.5  205.7 219.4 4.97  5.78 12.4  1.0  17.2  -12.8 -5.9   -4.5  -7.1  0.7   7.1    19.0  0.21  0.33  -5.8  99.2  34.2 42.7 81.9 90.7 75.9  99.5 81.1 18.4  85.9  62.1 77.1 .
+8  82.2  231.2 269.8 288.7 155.4 58.5  78.6  201.2 206.9 4.84  5.63 10.6  0.0  -2.3  -4.9  -17.3  2.8   3.1   -0.9  11.8   10.0  0.23  0.27  -12.5 100.0 98.8 91.5 54.7 96.2 98.0  98.7 73.3 70.7  83.4  79.2 66.8 .
+9  82.5  202.9 63.1  167.2 142.6 47.1  145.1 219.4 229.6 4.94  6.37 312.8 1.1  -7.3  14.3  1.3    -6.9  -1.8  -2.2  11.8   4.0   0.32  0.35  6.8   97.8  84.5 59.8 99.7 91.9 99.2  95.1 62.0 95.1  59.6  48.6 83.3 .
+10 78.6  219.0 58.4  166.4 136.7 49.9  142.8 206.9 230.2 5.10  6.46 315.6 -2.8 8.8   9.5   0.6    -12.8 1.0   -4.5  -0.7   4.6   0.48  0.44  9.6   85.6  78.4 79.5 99.9 75.1 99.8  81.0 99.8 93.8  31.5  32.1 69.4 .
+11 146.2 243.2 66.4  80.0  186.1 54.5  139.0 46.8  250.2 10.27 8.15 260.7 -3.2 0.9   -13.2 13.3   8.7   -8.0  -4.9  178.5  6.3   0.01  -0.09 16.1  92.5  99.7 54.7 64.9 61.2 84.2  91.6 0.0  88.7  100.0 87.2 51.6 cAnch1;cNnch1
+12 151.0 251.6 61.9  81.5  173.8 49.3  146.3 60.3  245.4 10.08 8.04 247.5 1.6  9.4   -17.6 14.8   -3.7  -13.2 2.4   -168.0 1.5   -0.18 -0.20 2.9   98.1  70.8 33.9 58.5 91.4 62.8  98.0 0.0  99.3  87.0  50.5 97.9 cAnz1;cAnch1;cNnz1;cNnch1
+13 139.0 251.9 297.2 297.0 232.2 60.0  146.2 250.2 242.8 10.29 8.51 90.2  -1.0 -19.1 14.3  -0.6   41.7  4.3   -1.9  -9.6   25.6  1.73  0.68  23.2  99.5  41.0 59.3 99.9 0.6  94.9  97.8 81.8 18.6  0.1   14.1 26.7 cAnb2;cNnb2
+14 146.3 261.3 294.1 313.3 218.4 46.5  137.9 245.4 236.0 10.24 8.51 87.0  6.3  -9.7  11.2  15.7   27.9  -9.2  -10.2 -14.3  18.9  1.67  0.67  20.1  82.6  79.5 72.6 59.6 10.2 78.8  53.8 63.8 40.1  0.2   14.4 37.3 .
+15 146.2 261.9 192.9 52.3  217.7 210.2 79.4  242.8 191.6 5.02  5.36 33.7  -0.3 16.1  3.3   -9.1   -10.9 11.6  -5.3  -23.2  -7.5  0.59  0.54  4.9   99.9  59.4 98.0 82.3 71.8 69.6  77.9 30.1 75.2  41.8  49.6 82.8 .
+16 137.9 184.6 239.7 297.6 180.8 46.4  79.1  236.0 202.4 5.15  5.63 40.7  -0.9 -23.4 26.8  -3.1   39.4  -2.6  -9.8  -27.3  -12.4 0.72  0.71  7.5   99.7  32.3 25.0 98.2 2.8  98.5  77.3 17.6 72.3  21.0  22.6 72.3 cAnb2
+17 79.4  241.7 254.4 305.2 148.7 46.9  83.0  191.6 206.0 4.97  5.72 16.3  -2.8 8.3   -20.4 -0.7   -3.9  -8.5  3.5   2.2    9.0   0.37  0.36  -6.7  93.2  84.8 22.2 99.9 92.4 86.3  83.9 98.9 75.4  63.5  65.4 89.0 .
+18 79.1  223.6 269.7 286.7 161.8 55.3  82.8  202.4 211.9 5.07  5.75 10.7  -3.1 -9.9  -5.1  -19.2  9.1   -0.1  3.3   13.0   15.0  0.47  0.39  -12.3 91.6  79.2 91.2 47.4 65.8 100.0 85.3 68.3 46.0  48.2  60.5 67.6 .
+19 83.0  205.0 68.3  168.8 144.2 45.2  140.2 206.0 225.8 5.04  6.47 321.4 1.5  -5.2  19.5  3.0    -5.3  -3.7  -7.1  -1.7   0.2   0.43  0.45  15.4  95.6  91.8 38.4 98.2 95.2 96.9  59.1 99.0 100.0 40.1  31.1 38.9 .
+20 82.8  206.8 64.9  162.6 142.6 47.3  143.8 211.9 226.7 5.00  6.40 317.9 1.4  -3.5  16.0  -3.2   -6.9  -1.6  -3.5  4.3    1.1   0.39  0.38  11.9  96.5  96.3 52.4 97.9 91.9 99.4  88.0 94.0 99.7  47.6  43.1 57.0 .
+
+loop_
+_ndb_struct_sugar_step_parameters.step_id
+_ndb_struct_sugar_step_parameters.P_1
+_ndb_struct_sugar_step_parameters.tau_1
+_ndb_struct_sugar_step_parameters.Pn_1
+_ndb_struct_sugar_step_parameters.P_2
+_ndb_struct_sugar_step_parameters.tau_2
+_ndb_struct_sugar_step_parameters.Pn_2
+_ndb_struct_sugar_step_parameters.nu_1_1
+_ndb_struct_sugar_step_parameters.nu_1_2
+_ndb_struct_sugar_step_parameters.nu_1_3
+_ndb_struct_sugar_step_parameters.nu_1_4
+_ndb_struct_sugar_step_parameters.nu_1_5
+_ndb_struct_sugar_step_parameters.nu_2_1
+_ndb_struct_sugar_step_parameters.nu_2_2
+_ndb_struct_sugar_step_parameters.nu_2_3
+_ndb_struct_sugar_step_parameters.nu_2_4
+_ndb_struct_sugar_step_parameters.nu_2_5
+_ndb_struct_sugar_step_parameters.diff_nu_1_1
+_ndb_struct_sugar_step_parameters.diff_nu_1_2
+_ndb_struct_sugar_step_parameters.diff_nu_1_3
+_ndb_struct_sugar_step_parameters.diff_nu_1_4
+_ndb_struct_sugar_step_parameters.diff_nu_1_5
+_ndb_struct_sugar_step_parameters.diff_nu_2_1
+_ndb_struct_sugar_step_parameters.diff_nu_2_2
+_ndb_struct_sugar_step_parameters.diff_nu_2_3
+_ndb_struct_sugar_step_parameters.diff_nu_2_4
+_ndb_struct_sugar_step_parameters.diff_nu_2_5
+1  184.7 31.5 C3exo 159.6 36.5 C2end 352.2 24.7  328.6 27.7  347.3 336.4 36.1  325.8 21.5  1.1   11.8 -10.7 5.5  1.1  -8.2  -3.3  2.3   -0.3 -1.5 3.0
+2  181.2 34.9 C3exo 161.5 40.0 C2end 349.3 28.6  325.1 29.6  348.0 335.3 39.2  322.1 24.7  359.9 8.9  -6.8  2.0  3.0  -7.5  -4.5  5.4   -4.0 1.7  1.8
+3  159.6 36.5 C2end 352.4 37.7 C2exo 336.4 36.1  325.8 21.5  1.1   17.3  325.8 37.4  331.2 7.4   -1.8 1.3   -0.3 -0.7 1.6   19.0  -14.2 4.4  6.0  -15.8
+4  161.5 40.0 C2end 2.3   40.8 C3end 335.3 39.2  322.1 24.7  359.9 11.8  326.9 40.8  324.9 14.7  -3.0 4.4   -3.9 2.5  0.4   13.5  -13.1 7.8  -0.3 -8.4
+5  352.4 37.7 C2exo 12.0  37.1 C3end 17.3  325.8 37.4  331.2 7.4   4.4   334.3 36.3  325.3 19.2  16.2 -8.3  -2.1 10.9 -17.0 4.3   -0.5  -2.9 5.3  -6.0
+6  2.3   40.8 C3end 12.7  37.3 C3end 11.8  326.9 40.8  324.9 14.7  3.9   334.5 36.3  325.0 19.6  10.7 -7.1  1.3  4.6  -9.6  3.8   -0.2  -2.8 5.0  -5.5
+7  12.0  37.1 C3end 12.4  38.0 C3end 4.4   334.3 36.3  325.3 19.2  4.3   333.7 37.1  324.3 19.8  3.4  0.2   -3.2 5.0  -5.2  4.2   -1.0  -2.1 4.3  -5.3
+8  12.7  37.3 C3end 16.7  39.4 C3end 3.9   334.5 36.3  325.0 19.6  1.4   335.1 37.8  321.9 23.1  -1.7 2.0   -1.4 0.4  0.8   -0.2  0.4   -0.4 0.2  -0.1
+9  12.4  38.0 C3end 156.9 40.2 C2end 4.3   333.7 37.1  324.3 19.8  332.7 40.4  323.0 22.2  3.1   3.3  -2.9  1.4  0.4  -2.4  -4.5  3.5   -0.9 -1.6 4.0
+10 16.7  39.4 C3end 155.5 39.6 C2end 1.4   335.1 37.8  321.9 23.1  332.3 39.9  324.0 21.0  4.0   0.4  -1.5  2.0  -1.9 0.8   -4.8  3.0   0.1  -2.9 4.9
+11 159.8 38.5 C2end 152.2 35.9 C2end 335.3 38.1  323.9 22.9  0.9   333.3 36.4  328.2 17.2  5.8   -5.1 2.7   0.9  -3.7 5.5   -6.5  2.6   2.1  -5.8 7.7
+12 166.9 38.2 C2end 161.7 37.9 C2end 339.4 36.3  322.8 26.4  356.2 336.8 37.0  324.0 23.4  359.7 -1.0 0.8   -0.3 -0.2 0.8   -3.0  3.3   -2.1 0.4  1.7
+13 152.2 35.9 C2end 149.5 44.6 C2end 333.3 36.4  328.2 17.2  5.8   325.4 45.9  321.6 20.0  9.1   -1.0 0.9   -0.3 -0.3 0.8   -15.7 11.4  -2.4 -6.1 13.7
+14 161.7 37.9 C2end 148.3 41.1 C2end 336.8 37.0  324.0 23.4  359.7 327.8 42.3  325.1 17.4  9.3   2.5  1.5   -4.5 5.9  -5.2  -13.3 7.9   1.1  -8.7 14.0
+15 149.5 44.6 C2end 14.5  39.3 C3end 325.4 45.9  321.6 20.0  9.1   2.9   334.0 38.1  322.6 21.8  -3.3 2.4   0.1  -1.7 3.3   1.7   -3.3  3.5  -2.5 0.5
+16 148.3 41.1 C2end 17.8  38.6 C3end 327.8 42.3  325.1 17.4  9.3   0.6   336.4 36.7  322.7 23.2  1.2  -0.6  0.7  -0.0 -0.5  15.9  -17.8 13.7 -5.0 -6.9
+17 14.5  39.3 C3end 12.4  37.5 C3end 2.9   334.0 38.1  322.6 21.8  4.2   334.1 36.6  324.7 19.6  -2.8 1.4   0.4  -1.9 2.9   2.6   -0.6  -1.6 2.9  -3.5
+18 17.8  38.6 C3end 12.9  38.1 C3end 0.6   336.4 36.7  322.7 23.2  3.9   334.0 37.1  324.1 20.1  -5.1 3.8   -1.0 -1.9 4.3   2.3   -0.6  -1.1 2.4  -3.0
+19 12.4  37.5 C3end 154.7 36.2 C2end 4.2   334.1 36.6  324.7 19.6  334.2 36.5  327.3 18.7  4.2   3.2  -2.5  0.9  0.8  -2.6  -2.9  -0.4  3.3  -5.1 5.1
+20 12.9  38.1 C3end 154.9 39.6 C2end 3.9   334.0 37.1  324.1 20.1  331.9 40.0  324.1 20.7  4.3   3.0  -2.6  1.4  0.3  -2.1  -5.2  3.1   0.2  -3.1 5.2
+
+loop_
+_ndb_base_pair_list.base_pair_id
+_ndb_base_pair_list.PDB_model_number
+_ndb_base_pair_list.asym_id_1
+_ndb_base_pair_list.entity_id_1
+_ndb_base_pair_list.seq_id_1
+_ndb_base_pair_list.comp_id_1
+_ndb_base_pair_list.PDB_ins_code_1
+_ndb_base_pair_list.alt_id_1
+_ndb_base_pair_list.struct_oper_id_1
+_ndb_base_pair_list.asym_id_2
+_ndb_base_pair_list.entity_id_2
+_ndb_base_pair_list.seq_id_2
+_ndb_base_pair_list.comp_id_2
+_ndb_base_pair_list.PDB_ins_code_2
+_ndb_base_pair_list.alt_id_2
+_ndb_base_pair_list.struct_oper_id_2
+_ndb_base_pair_list.auth_asym_id_1
+_ndb_base_pair_list.auth_seq_id_1
+_ndb_base_pair_list.auth_asym_id_2
+_ndb_base_pair_list.auth_seq_id_2
+1  1 A 1 1 G ? A 3 A 1 1 G ? A 1 A 1 A 1
+2  1 A 1 1 G ? A 1 A 1 1 G ? A 4 A 1 A 1
+3  1 A 1 1 G ? A 4 A 1 1 G ? A 2 A 1 A 1
+4  1 A 1 1 G ? A 2 A 1 1 G ? A 3 A 1 A 1
+5  1 A 1 1 G ? B 3 A 1 1 G ? B 1 A 1 A 1
+6  1 A 1 1 G ? B 1 A 1 1 G ? B 4 A 1 A 1
+7  1 A 1 1 G ? B 4 A 1 1 G ? B 2 A 1 A 1
+8  1 A 1 1 G ? B 2 A 1 1 G ? B 3 A 1 A 1
+9  1 A 1 3 G ? A 3 A 1 3 G ? A 1 A 3 A 3
+10 1 A 1 3 G ? A 1 A 1 3 G ? A 4 A 3 A 3
+11 1 A 1 3 G ? A 4 A 1 3 G ? A 2 A 3 A 3
+12 1 A 1 3 G ? A 2 A 1 3 G ? A 3 A 3 A 3
+13 1 A 1 3 G ? B 3 A 1 3 G ? B 1 A 3 A 3
+14 1 A 1 3 G ? B 1 A 1 3 G ? B 4 A 3 A 3
+15 1 A 1 3 G ? B 4 A 1 3 G ? B 2 A 3 A 3
+16 1 A 1 3 G ? B 2 A 1 3 G ? B 3 A 3 A 3
+17 1 A 1 4 U ? A 3 A 1 4 U ? A 1 A 4 A 4
+18 1 A 1 4 U ? A 1 A 1 4 U ? A 4 A 4 A 4
+19 1 A 1 4 U ? A 4 A 1 4 U ? A 2 A 4 A 4
+20 1 A 1 4 U ? A 2 A 1 4 U ? A 3 A 4 A 4
+21 1 A 1 5 G ? A 3 A 1 5 G ? A 1 A 5 A 5
+22 1 A 1 5 G ? A 1 A 1 5 G ? A 4 A 5 A 5
+23 1 A 1 5 G ? A 4 A 1 5 G ? A 2 A 5 A 5
+24 1 A 1 5 G ? A 2 A 1 5 G ? A 3 A 5 A 5
+25 1 A 1 5 G ? B 3 A 1 5 G ? B 1 A 5 A 5
+26 1 A 1 5 G ? B 1 A 1 5 G ? B 4 A 5 A 5
+27 1 A 1 5 G ? B 4 A 1 5 G ? B 2 A 5 A 5
+28 1 A 1 5 G ? B 2 A 1 5 G ? B 3 A 5 A 5
+29 1 A 1 6 U ? A 4 A 1 6 U ? A 1 A 6 A 6
+30 1 A 1 6 U ? A 1 A 1 6 U ? A 3 A 6 A 6
+31 1 A 1 6 U ? A 3 A 1 6 U ? A 2 A 6 A 6
+32 1 A 1 6 U ? A 2 A 1 6 U ? A 4 A 6 A 6
+33 1 A 1 6 U ? B 4 A 1 6 U ? B 1 A 6 A 6
+34 1 A 1 6 U ? B 1 A 1 6 U ? B 3 A 6 A 6
+35 1 A 1 6 U ? B 3 A 1 6 U ? B 2 A 6 A 6
+36 1 A 1 6 U ? B 2 A 1 6 U ? B 4 A 6 A 6
+37 1 B 1 1 G ? A 4 B 1 1 G ? A 1 B 1 B 1
+38 1 B 1 1 G ? A 1 B 1 1 G ? A 3 B 1 B 1
+39 1 B 1 1 G ? A 3 B 1 1 G ? A 2 B 1 B 1
+40 1 B 1 1 G ? A 2 B 1 1 G ? A 4 B 1 B 1
+41 1 B 1 1 G ? B 4 B 1 1 G ? B 1 B 1 B 1
+42 1 B 1 1 G ? B 1 B 1 1 G ? B 3 B 1 B 1
+43 1 B 1 1 G ? B 3 B 1 1 G ? B 2 B 1 B 1
+44 1 B 1 1 G ? B 2 B 1 1 G ? B 4 B 1 B 1
+45 1 B 1 3 G ? A 4 B 1 3 G ? A 1 B 3 B 3
+46 1 B 1 3 G ? A 1 B 1 3 G ? A 3 B 3 B 3
+47 1 B 1 3 G ? A 3 B 1 3 G ? A 2 B 3 B 3
+48 1 B 1 3 G ? A 2 B 1 3 G ? A 4 B 3 B 3
+49 1 B 1 3 G ? B 4 B 1 3 G ? B 1 B 3 B 3
+50 1 B 1 3 G ? B 1 B 1 3 G ? B 3 B 3 B 3
+51 1 B 1 3 G ? B 3 B 1 3 G ? B 2 B 3 B 3
+52 1 B 1 3 G ? B 2 B 1 3 G ? B 4 B 3 B 3
+53 1 B 1 4 U ? A 4 B 1 4 U ? A 1 B 4 B 4
+54 1 B 1 4 U ? A 1 B 1 4 U ? A 3 B 4 B 4
+55 1 B 1 4 U ? A 3 B 1 4 U ? A 2 B 4 B 4
+56 1 B 1 4 U ? A 2 B 1 4 U ? A 4 B 4 B 4
+57 1 B 1 4 U ? B 4 B 1 4 U ? B 1 B 4 B 4
+58 1 B 1 4 U ? B 1 B 1 4 U ? B 3 B 4 B 4
+59 1 B 1 4 U ? B 3 B 1 4 U ? B 2 B 4 B 4
+60 1 B 1 4 U ? B 2 B 1 4 U ? B 4 B 4 B 4
+61 1 B 1 5 G ? A 4 B 1 5 G ? A 1 B 5 B 5
+62 1 B 1 5 G ? A 1 B 1 5 G ? A 3 B 5 B 5
+63 1 B 1 5 G ? A 3 B 1 5 G ? A 2 B 5 B 5
+64 1 B 1 5 G ? A 2 B 1 5 G ? A 4 B 5 B 5
+65 1 B 1 5 G ? B 4 B 1 5 G ? B 1 B 5 B 5
+66 1 B 1 5 G ? B 1 B 1 5 G ? B 3 B 5 B 5
+67 1 B 1 5 G ? B 3 B 1 5 G ? B 2 B 5 B 5
+68 1 B 1 5 G ? B 2 B 1 5 G ? B 4 B 5 B 5
+69 1 B 1 6 U ? A 3 B 1 6 U ? A 1 B 6 B 6
+70 1 B 1 6 U ? A 1 B 1 6 U ? A 4 B 6 B 6
+71 1 B 1 6 U ? A 4 B 1 6 U ? A 2 B 6 B 6
+72 1 B 1 6 U ? A 2 B 1 6 U ? A 3 B 6 B 6
+73 1 B 1 6 U ? B 3 B 1 6 U ? B 1 B 6 B 6
+74 1 B 1 6 U ? B 1 B 1 6 U ? B 4 B 6 B 6
+75 1 B 1 6 U ? B 4 B 1 6 U ? B 2 B 6 B 6
+76 1 B 1 6 U ? B 2 B 1 6 U ? B 3 B 6 B 6
+
+loop_
+_ndb_base_pair_annotation.id
+_ndb_base_pair_annotation.base_pair_id
+_ndb_base_pair_annotation.orientation
+_ndb_base_pair_annotation.base_1_edge
+_ndb_base_pair_annotation.base_2_edge
+_ndb_base_pair_annotation.l-w_family_num
+_ndb_base_pair_annotation.l-w_family
+_ndb_base_pair_annotation.class
+_ndb_base_pair_annotation.subclass
+1  1  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+2  2  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+3  3  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+4  4  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+5  5  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+6  6  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+7  7  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+8  8  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+9  9  cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+10 10 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+11 11 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+12 12 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+13 13 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+14 14 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+15 15 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+16 16 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+17 17 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+18 18 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+19 19 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+20 20 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+21 21 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+22 22 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+23 23 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+24 24 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+25 25 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+26 26 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+27 27 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+28 28 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+29 29 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+30 30 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+31 31 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+32 32 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+33 33 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+34 34 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+35 35 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+36 36 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+37 37 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+38 38 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+39 39 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+40 40 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+41 41 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+42 42 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+43 43 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+44 44 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+45 45 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+46 46 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+47 47 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+48 48 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+49 49 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+50 50 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+51 51 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+52 52 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+53 53 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+54 54 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+55 55 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+56 56 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+57 57 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+58 58 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+59 59 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+60 60 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+61 61 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+62 62 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+63 63 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+64 64 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+65 65 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+66 66 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+67 67 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+68 68 cis Watson-Crick Hoogsteen 3 cWH cWH_G-G cWH_G-G_1
+69 69 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+70 70 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+71 71 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+72 72 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+73 73 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+74 74 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+75 75 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+76 76 cis Watson-Crick Hoogsteen 3 cWH cWH_U-U cWH_U-U_1
+
+loop_
+_ndb_base_unpaired_list.id
+_ndb_base_unpaired_list.PDB_model_num
+_ndb_base_unpaired_list.label_entity_id
+_ndb_base_unpaired_list.label_asym_id
+_ndb_base_unpaired_list.label_seq_id
+_ndb_base_unpaired_list.label_comp_id
+_ndb_base_unpaired_list.label_alt_id
+_ndb_base_unpaired_list.PDB_ins_code
+_ndb_base_unpaired_list.auth_asym_id
+_ndb_base_unpaired_list.auth_seq_id
+1 1 1 A 2 U . ? A 2
+2 1 1 B 2 U . ? B 2

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/README.md
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/README.md
@@ -137,6 +137,83 @@ tWS         : ....(....................)..(.............)............
 tHW         : ....(....................................).............
 ```
 
+### 6. Unpaired residues
+
+A `.` in a bracket row means "this residue has no partner **on that layer**"
+— that is a per-row statement. With `--unpaired`, the script adds a single
+`#`-prefixed comment line summarising "this residue has no partner **anywhere
+in the structure**". Both views coexist; one is per-layer, the other is
+structural.
+
+```
+$ python3 standalone_lbn_script.py 9HRF.cif --unpaired
+>9HRF|A
+# unpaired (13): A8, A11, A29-32, A44, A49-51, A61, A69-70  [derived from pair list]
+seq         : GGGCGCAUUUUGGUAGGUCGGUCGCUGCUUCGGCAGUGAGGGGUAGGCAUUGCUGGCCUAGGGUGCCCUU
+WC          : ((((.(...(...[[[[.[.[((.((((....)))).)).....)..(...)].].]]]]..).))))..
+...
+```
+
+Consecutive residue numbers within one strand are collapsed to ranges
+(`A29-32` instead of `A29, A30, A31, A32`); symmetry mates use the same
+bracketed-operator form the rest of the script uses (e.g. `A2[2_565]`).
+
+**Source rule.** The script picks where to get the unpaired list using a
+simple two-step check:
+
+1. **If the CIF contains `_ndb_base_unpaired_list`** — DNATCO's own
+   per-model annotation — read it directly (model 1 by default). This is the
+   authoritative source, particularly for NMR ensembles where the unpaired
+   set varies across models.
+2. **Otherwise** — derive it from `_ndb_base_pair_list`: every residue in
+   the chain that never appears in any pair row is unpaired.
+
+The output records which source was used:
+
+```
+# unpaired (4): A12-15  [from _ndb_base_unpaired_list, model 1]
+# unpaired (2): A13-14  [derived from pair list]
+```
+
+The bundled `examples/8VJT.cif` is the only example file shipped with the
+`_ndb_base_unpaired_list` block already populated, so it is the easiest way
+to try the "from `_ndb_base_unpaired_list`" path:
+
+```
+python3 standalone_lbn_script.py examples/8VJT.cif --unpaired
+# >8VJT|A|A:2_565|...
+# # unpaired (2): A2, B2  [from _ndb_base_unpaired_list, model 1]
+```
+
+The same 8VJT through the FR3D path (which has no separate unpaired list)
+derives the unpaired set from the TSV instead, and reports it across every
+displayed strand including the symmetry mates:
+
+```
+python3 layered_basepairs.py examples/8VJT.cif examples/8vjt_fr3d_basepairs.tsv --unpaired
+# # unpaired (8): A2, A2[2_565], A2[3_555], A2[4_455], B2, ...  [derived from FR3D pair list]
+```
+
+Both views are correct for the scope they describe (asymmetric unit vs the
+displayed assembly).
+
+The FR3D-driven script (`layered_basepairs.py`) always derives, since FR3D
+ships only a pair list.
+
+**Why a `#` comment line and not a new bracket row?** Standard 2D viewers
+(VARNA, R2DT, forna, fornac, ViennaRNA) require `.` for unpaired in
+dot-bracket. Putting a custom marker on a bracket row would either break
+bracket balance (`(` for unpaired) or break tool compatibility (`_`, `-`).
+A `#` comment follows the FASTA / Stockholm convention, is ignored by every
+standard tool, and stays human-readable. It also round-trips correctly:
+`notation_to_cif.py` ignores `#` lines, so the comment never affects the
+rebuilt CIF.
+
+The display-filter is honoured **but the count is structural**, by design:
+running `--unpaired --noncanonical` reports the same residues as `--unpaired`
+alone, because a residue paired only via Watson-Crick is still paired in the
+structure — its pair is just hidden when the WC layer is dropped from view.
+
 ## `standalone_lbn_script.py` — also draws the pairs in 3D
 
 If your CIF already carries the DNATCO base-pair annotation
@@ -258,7 +335,7 @@ would need structural modelling and is out of scope here.
 
 ## Common flags
 
-Both scripts share these flags:
+Both forward scripts share these flags:
 
 | Flag | Effect |
 | --- | --- |
@@ -266,8 +343,9 @@ Both scripts share these flags:
 | `--noncanonical` | Drop true Watson-Crick pairs entirely (the `WC` row becomes absent). cWW U-U / U-G wobbles still appear on the `cWW` row. |
 | `--layer` | Prepend slot numbers to each row label (`L0 WC`, `L1 cWW`, `L10 tWW`, ...). Off by default. |
 | `--metadata` | Add a `# chains: A[1_555](1-59); '&' separates chains` comment line below the header. The line starts with `#` so any parser ignores it. |
-| `--block N` | Wrap lines into fixed-width blocks of N columns (handy for long sequences). |
-| `--name NAME` | Header name (default `RNA`). |
+| `--unpaired` | Add a `# unpaired (N): A8, A11, A29-32, ...` comment line listing residues that have no pair. Consecutive residues within a strand are collapsed to ranges. See **Unpaired residues** below for how the source is chosen. |
+| `--block N` | Wrap lines into fixed-width blocks of N columns (handy for long sequences). `--block` with no value uses 100 columns. |
+| `--name NAME` | Header label. **Default: read from the CIF itself** (`_entry.id`, falling back to the `data_XXXX` block name at the top of the file). So for `8BWT.cif` you get `>8BWT|...` without typing `--name`. |
 
 ## Requirements
 
@@ -286,12 +364,13 @@ conda activate lbn
 ### From an FR3D TSV (any mmCIF for sequence/numbering)
 
 ```
-python3 layered_basepairs.py <cif> <tsv> [chains...] [--name NAME] [--block N]
-                              [--compact] [--noncanonical] [--layer] [--metadata]
+python3 layered_basepairs.py <cif> <tsv> [chains...] [options]
 ```
 
-The chain ids are optional — with none given, all chains present in the FR3D
-TSV are used automatically.
+Optional flags: `--name`, `--block`, `--compact`, `--noncanonical`, `--layer`,
+`--metadata`, `--unpaired`. With no chains, every chain present in the FR3D
+TSV is used automatically. With no `--name`, the label is read from the
+CIF's `_entry.id`.
 
 Base pairs come from the FR3D basepairs TSV (provided in `examples/`); the
 matching mmCIF is downloaded from RCSB. For example, the 1XPE kissing-loop
@@ -299,20 +378,32 @@ dimer:
 
 ```
 wget https://files.rcsb.org/download/1XPE.cif
-python3 layered_basepairs.py 1XPE.cif examples/1xpe_fr3d_basepairs.tsv A B --name 1XPE
+python3 layered_basepairs.py 1XPE.cif examples/1xpe_fr3d_basepairs.tsv A B
 # or let it pick up the chains itself:
-python3 layered_basepairs.py 1XPE.cif examples/1xpe_fr3d_basepairs.tsv --name 1XPE
+python3 layered_basepairs.py 1XPE.cif examples/1xpe_fr3d_basepairs.tsv
 ```
 
 ### From a DNATCO-extended mmCIF (no external pair list)
 
 ```
-python3 standalone_lbn_script.py <cif> [chains...] [--name NAME] [--id PDBID]
-                                  [--compact] [--noncanonical] [--layer]
-                                  [--metadata] [--block N] [--script FILE]
+python3 standalone_lbn_script.py <cif> [chains...] [options]
 ```
 
-`--id` overrides the PDB id iCn3D loads (defaults to the CIF file stem).
+Optional flags: `--name`, `--id`, `--compact`, `--noncanonical`, `--layer`,
+`--metadata`, `--unpaired`, `--block`, `--script FILE`. With no chains,
+every chain that appears in the pair list is used.
+
+- `--name` defaults to `_entry.id` from the CIF (or the `data_XXXX` block name).
+- `--id` overrides the PDB id iCn3D should load (defaults to the CIF file stem,
+  lowercased).
+- `--unpaired` reads `_ndb_base_unpaired_list` when the CIF contains it
+  (DNATCO's own per-model annotation), otherwise derives from the pair list.
+
+Minimal invocation, everything auto-detected:
+
+```
+python3 standalone_lbn_script.py 8BWT.cif --unpaired
+```
 
 The notation goes to stdout; the round-trip check (`True` = lossless) is
 printed to stderr. The standalone additionally emits iCn3D `add line` commands

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/common.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/common.py
@@ -163,6 +163,24 @@ def read_residues(cif: Path, chains: list[str]) -> dict[str, list]:
             else _read_atom_site(lines, chains))
 
 
+def read_entry_id(cif: Path) -> str | None:
+    """PDB id / entry id read from the CIF itself. Prefers _entry.id; if that
+    is missing or set to '?' / '.', falls back to the 'data_XXXX' block name
+    at the top of the file. Returns None only if neither is present. Used as
+    the default for --name so the user does not have to type the id that the
+    file already declares about itself."""
+    data_block = None
+    for line in cif.read_text().splitlines():
+        s = line.strip()
+        if data_block is None and s.startswith("data_") and len(s) > 5:
+            data_block = s[5:]
+        elif s.startswith("_entry.id"):
+            parts = s.split()
+            if len(parts) >= 2 and parts[1] not in ("?", "."):
+                return parts[1].strip("'\"")
+    return data_block
+
+
 # --------------------------------------------------------------------------- #
 #  Layout, render and parse                                                    #
 # --------------------------------------------------------------------------- #

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/layered_basepairs.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/layered_basepairs.py
@@ -17,18 +17,36 @@ This file owns the FR3D-specific reading (unit-id parsing, pair list); the rest
 helpers -- lives in common.py.
 
 Usage:
-    python3 layered_basepairs.py <cif> <tsv> [chains...] [--name NAME]
-                                  [--block N] [--compact] [--noncanonical]
-                                  [--layer] [--metadata]
+    python3 layered_basepairs.py <cif> <tsv> [chains...] [options]
 
-With no chains, all chains present in the FR3D TSV are used automatically.
+The mmCIF is for sequence + residue numbers only (any vanilla CIF works).
+The FR3D TSV provides the base-pair list and Leontis-Westhof families.
 
-Examples (mmCIF from files.rcsb.org/download/<ID>.cif, basepairs TSV from FR3D):
-    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv A --name 9CFN
-    # no chains given -> all chains in the TSV are used
-    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv --name 9CFN
-    python3 layered_basepairs.py 1XPE.cif 1xpe_fr3d_basepairs.tsv A B --name 1XPE
-    python3 layered_basepairs.py 2Q1R.cif 2q1r_fr3d_basepairs.tsv A --name 2Q1R
+Examples -- most users only need the first one:
+
+    # 1. Simplest. --name auto-detected from the CIF; chains auto-picked from
+    #    every chain that appears in the TSV.
+    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv
+
+    # 2. Also list residues that have no pair (always derived from the TSV
+    #    here -- FR3D has no separate 'unpaired list' source).
+    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv --unpaired
+
+    # 3. Two-chain complex, pick the chain order on the ruler.
+    python3 layered_basepairs.py 1XPE.cif 1xpe_fr3d_basepairs.tsv A B
+
+    # 4. Non-canonical pairs only, with slot-numbered row labels (L0, L1, ...).
+    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv --noncanonical --layer
+
+    # 5. Long sequences: wrap into 100-column blocks AND keep non-canonical
+    #    rows as a short pair list instead of full-width dot-bracket.
+    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv --block --compact
+
+    # 6. Add a '# chains: ...' header comment describing each strand.
+    python3 layered_basepairs.py 2Q1R.cif 2q1r_fr3d_basepairs.tsv --metadata
+
+    # 7. Override the auto-detected name.
+    python3 layered_basepairs.py 9CFN.cif 9cfn_fr3d_basepairs.tsv --name MY-LABEL
 
 The notation prints to stdout; the round-trip result (True = lossless) to stderr.
 """
@@ -39,7 +57,7 @@ from pathlib import Path
 
 from common import (
     BLOCK, IDENTITY,
-    _flip_lw, build_notation, read_residues,
+    _flip_lw, build_notation, read_entry_id, read_residues,
 )
 
 
@@ -97,39 +115,60 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser(
         description="Layered base-pair notation for an RNA complex "
                     "(symmetry-aware), driven by an FR3D base-pair TSV.")
-    ap.add_argument("cif", type=Path, help="mmCIF file (sequence + residue numbers)")
-    ap.add_argument("tsv", type=Path, help="FR3D basepairs TSV")
+
+    # Positional --------------------------------------------------------------
+    ap.add_argument("cif", type=Path,
+                    help="input mmCIF (used only for sequence + residue numbers)")
+    ap.add_argument("tsv", type=Path, help="FR3D base-pair TSV file")
     ap.add_argument("chains", nargs="*",
-                    help="chain ids, in the order to lay them on the ruler; "
-                         "default: all chains present in the TSV")
-    ap.add_argument("--name", default="RNA", help="label for the header line")
-    ap.add_argument("--block", type=int, nargs="?", const=BLOCK, default=None,
-                    help=f"wrap lines into blocks of this many columns "
-                         f"(default {BLOCK} when given with no value)")
-    ap.add_argument("--compact", action="store_true",
-                    help="keep only the canonical WC layer as dot-bracket; "
-                         "print every non-canonical layer as an explicit pair "
-                         "list (e.g. A24,A31); saves space on large RNA")
+                    help="chain IDs in ruler order; "
+                         "default: every chain that appears in the TSV")
+
+    # Identity ----------------------------------------------------------------
+    ap.add_argument("--name", default=None,
+                    help="header label shown in the '>...' line; "
+                         "default: read from the CIF itself (_entry.id, or "
+                         "the 'data_XXXX' block name) -- so for 8BWT.cif you "
+                         "do not have to type --name 8BWT")
+
+    # Display filters ---------------------------------------------------------
     ap.add_argument("--noncanonical", action="store_true",
-                    help="show only non-canonical pairs (drop true Watson-Crick "
-                         "A-U/G-C/A-T); a cWW U-U or U-G wobble is kept on the "
-                         "cWW row")
+                    help="drop canonical Watson-Crick pairs (A-U, G-C, A-T) "
+                         "from the display; non-canonical cWW pairs "
+                         "(U-U / U-G wobbles) stay on the cWW row")
+    ap.add_argument("--compact", action="store_true",
+                    help="keep the canonical WC layer as full-width dot-bracket, "
+                         "but print every non-canonical layer as a short pair "
+                         "list (e.g. 'A24,A31  A25,A29'); saves vertical space "
+                         "on large RNAs")
+    ap.add_argument("--block", type=int, nargs="?", const=BLOCK, default=None,
+                    help=f"wrap each row into blocks of N columns "
+                         f"(default {BLOCK} when --block is given with no value); "
+                         f"useful for very long sequences")
+
+    # Row / strand labelling --------------------------------------------------
     ap.add_argument("--layer", action="store_true",
-                    help="prepend slot numbers to each layer label "
-                         "(L0 WC, L1 cWW, L10 tWW, ...); off by default")
+                    help="prepend slot numbers to each row label "
+                         "(L0 WC, L1 cWW, L2 cWH, ... L18 tSS); "
+                         "off by default -- labels are plain family names")
+
+    # Extra comment lines below the header -----------------------------------
     ap.add_argument("--metadata", action="store_true",
-                    help="add a '# chains: ...' comment line below the header "
-                         "with per-strand chain/symmetry/range info; off by default")
+                    help="add a '# chains: ...' line describing each strand "
+                         "(chain, symmetry operator, residue range)")
     ap.add_argument("--unpaired", action="store_true",
-                    help="add a '# unpaired (N): A8, A11, A29-32, ...' comment "
-                         "line below the header listing residues that "
-                         "participate in no displayed pair; off by default")
+                    help="add a '# unpaired (N): ...' line listing residues "
+                         "with no pair. Always derived from the FR3D TSV "
+                         "here -- FR3D has no separate 'unpaired list' source")
     a = ap.parse_args()
 
     chains = a.chains or list_chains(a.tsv)
     per_chain = read_residues(a.cif, chains)
     pairs = read_pairs(a.tsv, set(chains))
-    text, ok = build_notation(per_chain, pairs, chains, name=a.name,
+    # If --name wasn't given, pull it from the CIF so users don't have to retype
+    # the PDB id that the file already declares about itself.
+    name = a.name or read_entry_id(a.cif) or "RNA"
+    text, ok = build_notation(per_chain, pairs, chains, name=name,
                               block=a.block, compact=a.compact,
                               noncanonical=a.noncanonical,
                               show_layer=a.layer, show_metadata=a.metadata,

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/notation_to_cif.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/notation_to_cif.py
@@ -30,9 +30,25 @@ notation encoded.
 Usage:
     python3 notation_to_cif.py <notation.txt> <any.cif> -o <new.cif>
 
-    # produce the notation, then invert it, then verify
-    python3 standalone_lbn_script.py 9cfn.cif > 9cfn.lbn
-    python3 notation_to_cif.py 9cfn.lbn 9cfn.cif -o 9cfn_rebuilt.cif
+Examples -- the typical pattern is "forward, inverse, verify":
+
+    # 1. Forward: CIF -> notation
+    python3 standalone_lbn_script.py 8BWT.cif > 8BWT.lbn
+
+    # 2. Inverse: notation + any CIF of the same structure -> rebuilt CIF
+    python3 notation_to_cif.py 8BWT.lbn 8BWT.cif -o 8BWT_rebuilt.cif
+
+    # 3. Verify: the rebuilt CIF should yield the SAME notation
+    python3 standalone_lbn_script.py 8BWT_rebuilt.cif > 8BWT_rebuilt.lbn
+    diff 8BWT.lbn 8BWT_rebuilt.lbn   # empty == perfect round-trip
+
+    # Comment lines ('# chains: ...', '# unpaired: ...') in the notation are
+    # IGNORED by the parser, so a notation file produced with --metadata or
+    # --unpaired still round-trips correctly.
+
+    # The input CIF need NOT be DNATCO-extended -- a vanilla RCSB-downloaded
+    # CIF or even a minimal atom-site-only CIF works.
+    python3 notation_to_cif.py 9CFN.lbn vanilla_9CFN.cif -o 9CFN_with_pairs.cif
 """
 
 import argparse

--- a/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/standalone_lbn_script.py
+++ b/workstreams/ws2-prediction-non-Watson-Crick/layered-bp-notation/standalone_lbn_script.py
@@ -15,17 +15,43 @@ This file owns the CIF-specific reading (operator list, annotation, pair list,
 reading, the layered-notation builder, parser helpers -- lives in common.py.
 
 Usage:
-    python3 standalone_lbn_script.py <cif> [chains...] [--name NAME] [--id PDBID]
-                                     [--noncanonical] [--compact] [--block N]
-                                     [--layer] [--metadata] [--script FILE]
+    python3 standalone_lbn_script.py <cif> [chains...] [options]
 
-    python3 standalone_lbn_script.py 9cfn.cif --name 9cfn          # auto chains
-    python3 standalone_lbn_script.py 1XPE.cif A B --name 1XPE      # pick chains
-    python3 standalone_lbn_script.py 9cfn.cif --noncanonical       # only non-canonical
-    python3 standalone_lbn_script.py 9cfn.cif --script 9cfn.icn3d  # write a script file
+Examples -- most users only need the first one:
 
-The notation prints to stdout; the round-trip result and the iCn3D commands (or
-a --script file path) follow.
+    # 1. Simplest. --name and chains are auto-detected from the CIF.
+    python3 standalone_lbn_script.py 8BWT.cif
+
+    # 2. Also list residues that have no pair.
+    #    Source: _ndb_base_unpaired_list (DNATCO's own per-model annotation,
+    #    model 1) when present in the CIF; otherwise derived from the pair list.
+    python3 standalone_lbn_script.py 8BWT.cif --unpaired
+
+    # 3. Show only non-canonical pairs (drops A-U, G-C, A-T from the WC row).
+    python3 standalone_lbn_script.py 9HRF.cif --noncanonical
+
+    # 4. Big RNA: wrap each row into 100-column blocks AND keep non-canonical
+    #    rows as a short pair list instead of full-width dot-bracket.
+    python3 standalone_lbn_script.py 9CFN.cif --block --compact
+
+    # 5. Pick chains explicitly + add slot numbers to each row label.
+    python3 standalone_lbn_script.py 1XPE.cif A B --layer
+
+    # 6. Add a '# chains: ...' header comment describing each strand.
+    python3 standalone_lbn_script.py 1XPE.cif --metadata
+
+    # 7. Override the auto-detected name.
+    python3 standalone_lbn_script.py 8BWT.cif --name MY-LABEL
+
+    # 8. Write iCn3D commands to a file (load via File > Open in iCn3D)
+    #    instead of pasting them into the iCn3D command box.
+    python3 standalone_lbn_script.py 9CFN.cif --script 9CFN.icn3d
+
+    # 9. Flags compose freely.
+    python3 standalone_lbn_script.py 9CFN.cif --unpaired --metadata --layer --block
+
+The notation prints to stdout; the round-trip result and the iCn3D commands
+(or a --script file path) follow.
 """
 
 import argparse
@@ -35,7 +61,7 @@ from pathlib import Path
 from common import (
     BLOCK, DIRECTED, IDENTITY,
     _flip_lw, _is_canonical, _loop_columns, _read_loop_rows,
-    _res_id, build_notation, read_residues,
+    _res_id, build_notation, read_entry_id, read_residues,
 )
 
 
@@ -294,44 +320,73 @@ def build_icn3d_lines(cif: Path, chains: list[str], noncanonical: bool = False
 
 def main() -> None:
     ap = argparse.ArgumentParser(
-        description="Layered base-pair notation + iCn3D commands to draw the "
-                    "pairs in 3D, from a single annotated mmCIF.")
+        description="Layered base-pair notation + iCn3D 3D overlay, from a "
+                    "single DNATCO-annotated mmCIF.")
+
+    # Positional --------------------------------------------------------------
     ap.add_argument("cif", type=Path,
-                    help="mmCIF with _ndb_base_pair_list/_annotation categories")
+                    help="input mmCIF file (must contain _ndb_base_pair_list "
+                         "and _ndb_base_pair_annotation)")
     ap.add_argument("chains", nargs="*",
-                    help="chain ids in ruler order; default: all chains that pair")
-    ap.add_argument("--name", default="RNA", help="label for the notation header")
+                    help="chain IDs to lay on the ruler, in order; "
+                         "default: every chain that appears in the pair list")
+
+    # Identity ----------------------------------------------------------------
+    ap.add_argument("--name", default=None,
+                    help="header label shown in the '>...' line; "
+                         "default: read from the CIF itself (_entry.id, or "
+                         "the 'data_XXXX' block name) -- so for 8BWT.cif you "
+                         "do not have to type --name 8BWT")
     ap.add_argument("--id", default=None,
-                    help="PDB id iCn3D should load (default: the cif file name); "
-                         "must be an id iCn3D can load")
+                    help="PDB id iCn3D should load; "
+                         "default: the CIF filename stem, lowercased "
+                         "(e.g. 8BWT.cif -> 8bwt). Must be an id iCn3D can fetch.")
+
+    # Display filters ---------------------------------------------------------
     ap.add_argument("--noncanonical", action="store_true",
-                    help="draw only non-canonical pairs (cWW U-U/G-U included)")
-    ap.add_argument("--block", type=int, nargs="?", const=BLOCK, default=None,
-                    help=f"wrap notation lines into blocks of N columns "
-                         f"(default {BLOCK})")
+                    help="drop canonical Watson-Crick pairs (A-U, G-C, A-T) "
+                         "from the display; non-canonical cWW pairs "
+                         "(U-U / U-G wobbles) stay on the cWW row")
     ap.add_argument("--compact", action="store_true",
-                    help="keep only the canonical WC layer as dot-bracket; "
-                         "print every non-canonical layer as an explicit pair "
-                         "list (e.g. A24,A31); saves space on large RNA")
+                    help="keep the canonical WC layer as full-width dot-bracket, "
+                         "but print every non-canonical layer as a short pair "
+                         "list (e.g. 'A24,A31  A25,A29'); saves vertical space "
+                         "on large RNAs")
+    ap.add_argument("--block", type=int, nargs="?", const=BLOCK, default=None,
+                    help=f"wrap each row into blocks of N columns "
+                         f"(default {BLOCK} when --block is given with no value); "
+                         f"useful for very long sequences")
+
+    # Row / strand labelling --------------------------------------------------
     ap.add_argument("--layer", action="store_true",
-                    help="prepend slot numbers to each layer label "
-                         "(L0 WC, L1 cWW, L10 tWW, ...). Off by default: "
-                         "labels are plain family names (WC, cWW, tWW, ...)")
+                    help="prepend slot numbers to each row label "
+                         "(L0 WC, L1 cWW, L2 cWH, ... L18 tSS); "
+                         "off by default -- labels are plain family names")
+
+    # Extra comment lines below the header -----------------------------------
     ap.add_argument("--metadata", action="store_true",
-                    help="add a '# chains: ...' comment line below the header "
-                         "with per-strand chain/symmetry/range info "
-                         "(e.g. 'A[1_555](1-59)'); off by default")
+                    help="add a '# chains: ...' line describing each strand "
+                         "(chain, symmetry operator, residue range)")
     ap.add_argument("--unpaired", action="store_true",
-                    help="add a '# unpaired (N): A8, A11, A29-32, ...' comment "
-                         "line below the header listing residues that "
-                         "participate in no displayed pair; off by default")
+                    help="add a '# unpaired (N): ...' line listing residues "
+                         "with no hydrogen-bond partner. Source order: "
+                         "(1) _ndb_base_unpaired_list from the CIF when "
+                         "present (DNATCO's own per-model annotation, "
+                         "model 1 by default); (2) otherwise derive from "
+                         "the pair list (residue is unpaired iff it never "
+                         "appears in any pair row)")
+
+    # 3D overlay output -------------------------------------------------------
     ap.add_argument("--script", metavar="FILE",
-                    help="write the iCn3D commands to FILE (one per line) to "
-                         "load via File > Open File > State/Script File, "
-                         "instead of a URL")
+                    help="write iCn3D commands to FILE (one per line) so you "
+                         "can load them via File > Open File > State/Script "
+                         "File in iCn3D, instead of pasting into the command box")
     a = ap.parse_args()
 
     chains = a.chains or list_chains(a.cif)
+    # If --name wasn't given, pull it from the CIF itself so users don't have
+    # to retype the PDB id that the file already declares.
+    name = a.name or read_entry_id(a.cif) or "RNA"
 
     # 1) notation -- caller does the CIF reads, common.py does the layering.
     # Unpaired list: if the CIF ships _ndb_base_unpaired_list (DNATCO's own
@@ -346,7 +401,7 @@ def main() -> None:
             unpaired_source = "from _ndb_base_unpaired_list, model 1"
         else:
             unpaired_source = "derived from pair list"
-    text, ok = build_notation(per_chain, pairs, chains, name=a.name, block=a.block,
+    text, ok = build_notation(per_chain, pairs, chains, name=name, block=a.block,
                               compact=a.compact, noncanonical=a.noncanonical,
                               show_layer=a.layer, show_metadata=a.metadata,
                               show_unpaired=a.unpaired,


### PR DESCRIPTION
Three quality-of-life changes to the layered base-pair notation toolkit,
  refreshed docstrings + README, and a new example file that exercises
  every code path.
  
  ## 1. `--unpaired` picks its source automatically

  **If the CIF has `_ndb_base_unpaired_list`** (DNATCO's own per-model
  annotation), read it directly,  model 1 by default. Authoritative for
  NMR ensembles where the unpaired set varies across models.

  **Otherwise**, derive from `_ndb_base_pair_list`: every residue that
  never appears in any pair row is unpaired.

  The output line records which source was used:
  
  unpaired (4): A12-15  [from _ndb_base_unpaired_list, model 1]

  unpaired (2): A13-14  [derived from pair list]
  

  `layered_basepairs.py` (FR3D-driven) always derives, since FR3D ships
  only a pair list.

  ## 2. `--name` is now optional
  
  When `--name` is not given, the scripts read the PDB id from the CIF
  itself (`_entry.id`, falling back to the `data_XXXX` block name). So:
  
  ```bash
  python3 standalone_lbn_script.py 8BWT.cif --unpaired
  # header: >8BWT|A    (no --name needed)

  Explicit --name MYLABEL still wins.

  3. Refreshed docstrings + README

  Every script's top-of-file docstring now contains a numbered example
  block covering each flag combination (simplest invocation, --unpaired,
  --noncanonical, --block --compact, multi-chain, --metadata,
  explicit --name, --script for iCn3D, combined flags). Opening any
  script now teaches usage.

  README updates:
  - New Phase 6: Unpaired residues section explaining the source rule
  and the structural-not-displayed semantics.
  - --unpaired row added to the common-flags table.
  - --name row updated to document CIF-driven auto-detection.
  - Reproducing section commands no longer require --name.
  - Help strings inside argparse reorganised into clear groups (positional /
  identity / display filters / labelling / extra comments / output) and
  rewritten in plain language.
  
  4. New example: examples/8VJT.cif 

  A new bundled example file that uniquely exercises every code path in
  the toolkit:
  - symmetry-mate operators (4 mates per chain → 8 strands total),
  - multi-chain layout (A and B),
  - NMR ensemble (10 models), 
  - DNATCO's _ndb_base_unpaired_list block (the only example file
  shipped with this block already populated).
  
  Tested across all flags on both forward scripts and notation_to_cif.py,
  round-trip stays True everywhere; with --id 8vjt pinned the notation
  round-trips byte-identical.

  Files

  - common.py — new read_entry_id(); build_notation gained
  explicit_unpaired + unpaired_source params.
  - standalone_lbn_script.py — new read_unpaired_list(); --name
  defaults to read_entry_id(cif); refreshed docstring + help strings.
  - layered_basepairs.py — --name defaults to read_entry_id(cif);
  refreshed docstring + help strings.
  - notation_to_cif.py — refreshed docstring with the
  forward / inverse / verify example pattern. No behaviour change.
  - README.md — updated as described above.
  - examples/8VJT.cif — new example file (described above).
 
  
  Tested

  Comprehensive flag matrix on 8VJT.cif: every flag individually and
  all-flags-combined for both forward scripts (22 invocations total),
  plus notation_to_cif.py forward / inverse / re-derive. Round-trip
  True in all cases. Additionally verified on 8BWT, 9HRF, 8XZN, 1XPE,
  2Q1R , auto---name works, no regression.